### PR TITLE
Add F_File type

### DIFF
--- a/app/assets/css/app.scss
+++ b/app/assets/css/app.scss
@@ -3225,19 +3225,30 @@ canvas#webgl {
 
 .entityInstanceEditor {
 	position: absolute;
-	overflow: auto;
 	z-index: 10;
 
-	max-height: 90vh;
 	width: 200px;
 	box-sizing: border-box;
-	padding: 10px;
 
-
-	border-left: 4px solid $orange;
 	box-shadow: -4px 0px 16px rgba(0, 0, 0, 0.6);
 	background-color: $bgDark;
 
+	.entityInstanceWrapper {
+		overflow: auto;
+		max-height: 90vh;
+		padding: 10px;
+	}
+	
+	.resizeBar {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 4px;
+		height: 100%;
+		
+		background-color: $orange;
+		cursor: ew-resize;
+	}
 
 	header {
 		display: grid;
@@ -3322,6 +3333,11 @@ canvas#webgl {
 
 		button.removePoint {
 			flex: 0.2 1 0px;
+		}
+		
+		button.fileSelectButton {
+			flex: 0.2 1 0px;
+			padding: 8px 2px;
 		}
 
 		input[type=color] {
@@ -4656,7 +4672,7 @@ $patternSize : 32px;
 				grid-column: 2/3;
 				overflow: auto;
 
-				button.convert {
+				button.convert,.F_File.file-select {
 					padding: 4px;
 					flex: 0 1 0px;
 					align-self: stretch;
@@ -4745,8 +4761,14 @@ $patternSize : 32px;
 		ul.form.type-F_Enum .F_Enum,
 		ul.form.type-F_Point .F_Point,
 		ul.form.type-F_Text .F_Text,
-		ul.form.type-F_String .F_String {
+		ul.form.type-F_String .F_String,
+		ul.form.type-F_File .F_File {
 			display: flex;
+		}
+		
+		ul.form.type-F_File .F_File.file-select {
+			display: initial;
+			
 		}
 
 	}

--- a/app/assets/tpl/editEntityDefs.html
+++ b/app/assets/tpl/editEntityDefs.html
@@ -93,9 +93,10 @@
 			<div class="info identifier"></div>
 		</li>
 
-		<li class="F_Int F_Float F_String F_Text">
+		<li class="F_Int F_Float F_String F_Text F_File">
 			<label for="fDef">Default value</label>
 			<input type="text" name="fDef" placeholder="" id="fDef"/>
+			<button class="F_File file-select" id="fDefFile" name="fDefFile">Select file</button>
 		</li>
 
 		<li class="F_Bool">
@@ -114,9 +115,15 @@
 			<span>to</span>
 			<input type="text" name="max" id="max" placeholder="Max"/>
 		</li>
+		
+		<li class="F_File">
+			<label for="acceptTypes">Accept types</label>
+			<input type="text" name="acceptTypes" id="acceptTypes" placeholder=".*"/>
+			<div class="info" title="Semicolon-separated extensions with dot. For example: .png;.jpg;.gif"></div>
+		</li>
 
 
-		<li class="F_Int F_Float F_String F_Text F_Enum F_Point">
+		<li class="F_Int F_Float F_String F_Text F_Enum F_Point F_File">
 			<label for="canBeNull">Can be null</label>
 			<input type="checkbox" name="canBeNull" id="canBeNull"/>
 		</li>

--- a/src.data/data/DataTypes.hx
+++ b/src.data/data/DataTypes.hx
@@ -38,6 +38,7 @@ enum FieldType {
 	F_Color;
 	F_Enum(enumDefUid:Int);
 	F_Point;
+	F_File;
 }
 
 enum ValueWrapper {

--- a/src.data/data/inst/FieldInstance.hx
+++ b/src.data/data/inst/FieldInstance.hx
@@ -152,7 +152,7 @@ class FieldInstance {
 					setInternal( arrayIdx, V_Float(v) );
 				}
 
-			case F_String:
+			case F_String, F_File:
 				raw = StringTools.trim(raw);
 				if( raw.length==0 )
 					setInternal(arrayIdx, null);
@@ -228,6 +228,12 @@ class FieldInstance {
 					for( idx in 0...getArrayLength() )
 						if( getEnumValue(idx)==null )
 							return def.identifier;
+			
+			case F_File:
+				// TODO: Check file exists, path is localized.
+				// for( idx in 0...getArrayLength() )
+				// 	if( !def.canBeNull && !fileExists(idx) )
+				// 		return def.identifier;
 		}
 		return null;
 	}
@@ -237,7 +243,7 @@ class FieldInstance {
 			case F_Int: getInt(arrayIdx);
 			case F_Color: getColorAsInt(arrayIdx);
 			case F_Float: getFloat(arrayIdx);
-			case F_String, F_Text: getString(arrayIdx);
+			case F_String, F_Text, F_File: getString(arrayIdx);
 			case F_Bool: getBool(arrayIdx);
 			case F_Point: getPointStr(arrayIdx);
 			case F_Enum(name): getEnumValue(arrayIdx);
@@ -277,7 +283,7 @@ class FieldInstance {
 			case F_Int: getInt(arrayIdx);
 			case F_Color: getColorAsHexStr(arrayIdx);
 			case F_Float: getFloat(arrayIdx);
-			case F_String, F_Text: getString(arrayIdx);
+			case F_String, F_Text, F_File: getString(arrayIdx);
 			case F_Bool: getBool(arrayIdx);
 			case F_Enum(name): getEnumValue(arrayIdx);
 			case F_Point: getPointStr(arrayIdx);
@@ -288,7 +294,7 @@ class FieldInstance {
 			case F_Int, F_Float, F_Bool, F_Color: return Std.string(v);
 			case F_Enum(name): return '$v';
 			case F_Point: return '$v';
-			case F_String, F_Text: return '"$v"';
+			case F_String, F_Text, F_File: return '"$v"';
 		}
 	}
 
@@ -298,6 +304,7 @@ class FieldInstance {
 			case F_Float: JsonTools.writeFloat( getFloat(arrayIdx) );
 			case F_String: escapeStringForJson( getString(arrayIdx) );
 			case F_Text: escapeStringForJson( getString(arrayIdx) );
+			case F_File: escapeStringForJson( getString(arrayIdx) );
 			case F_Bool: getBool(arrayIdx);
 			case F_Color: getColorAsHexStr(arrayIdx);
 			case F_Point: getPointGrid(arrayIdx);
@@ -348,7 +355,7 @@ class FieldInstance {
 	}
 
 	public function getString(arrayIdx:Int) : String {
-		def.requireAny([ F_String, F_Text ]);
+		def.requireAny([ F_String, F_Text, F_File ]);
 		var out = isUsingDefault(arrayIdx) ? def.getStringDefault() : switch internalValues[arrayIdx] {
 			case V_String(v): v;
 			case _: throw "unexpected";
@@ -401,6 +408,7 @@ class FieldInstance {
 			case F_Text:
 			case F_Bool:
 			case F_Color:
+			case F_File:
 
 			case F_Point:
 				var i = 0;

--- a/src.renderer/Lang.hx
+++ b/src.renderer/Lang.hx
@@ -52,6 +52,7 @@ class Lang {
             case F_Bool: t._("Boolean");
             case F_Point: t._("Point");
             case F_Enum(name): name==null ? t._("Enum") : t._("Enum.::e::", { e:name });
+            case F_File: t._("File");
         }
     }
 
@@ -65,6 +66,7 @@ class Lang {
             case F_Bool: t._("✔");
             case F_Point: t._("X::sep::Y", { sep:Const.POINT_SEPARATOR });
             case F_Enum(name): t._("Enu");
+            case F_File: t._("f.le");
         }
     }
 }

--- a/src.renderer/exporter/Tiled.hx
+++ b/src.renderer/exporter/Tiled.hx
@@ -313,12 +313,13 @@ class Tiled extends Exporter {
 								case F_Color: "color";
 								case F_Enum(enumDefUid): null;
 								case F_Point: null;
+								case F_File: "file";
 							}
 							// Value
 							var v : Dynamic = switch fi.def.type {
 								case F_Int: fi.getInt(i);
 								case F_Float: fi.getFloat(i);
-								case F_String, F_Text: fi.getString(i);
+								case F_String, F_Text, F_File: fi.getString(i);
 								case F_Bool: fi.getBool(i);
 								case F_Color:
 									var c = fi.getColorAsHexStr(i);

--- a/src.renderer/misc/FieldTypeConverter.hx
+++ b/src.renderer/misc/FieldTypeConverter.hx
@@ -36,6 +36,14 @@ class FieldTypeConverter {
 				}
 			}
 		},
+		{
+			from:F_File, to:F_String, lossless:true,
+			convertInst:(fi,i)->{},
+		},
+		{
+			from:F_String, to:F_File, lossless:true,
+			convertInst:(fi,i)->{},
+		},
 
 
 		{

--- a/src.renderer/ui/FieldInstancesForm.hx
+++ b/src.renderer/ui/FieldInstancesForm.hx
@@ -289,6 +289,33 @@ class FieldInstancesForm {
 				});
 
 				hideInputIfDefault(arrayIdx, input, fi);
+			
+			case F_File:
+				var def = fi.def.getStringDefault();
+				var input = new J('<input class="fileInput" type="text"/>');
+				input.appendTo(jTarget);
+				input.attr("placeholder", def==null ? "(null)" : def=="" ? "(empty string)" : def);
+				if( !fi.isUsingDefault(arrayIdx) )
+					input.val( fi.getString(arrayIdx) );
+				// TODO: Proper icon
+				var fileSelect = new J('<button class="fileSelectButton">&#128269;</button>');
+				fileSelect.appendTo(jTarget);
+				
+				input.change( function(ev) {
+					fi.parseValue( arrayIdx, input.val() );
+					onFieldChange();
+				});
+				
+				fileSelect.click( function(ev) {
+					dn.electron.Dialogs.open(fi.def.acceptFileTypes, Editor.ME.getProjectDir(), function( absPath ) {
+						var relPath = Editor.ME.makeRelativeFilePath(absPath);
+						input.val(relPath);
+						fi.parseValue( arrayIdx, relPath );
+						onFieldChange();
+					});
+				});
+				
+				hideInputIfDefault(arrayIdx, input, fi);
 		}
 	}
 
@@ -460,7 +487,7 @@ class FieldInstancesForm {
 						}
 						var jArray = jWrapper.find('[defuid=${fd.uid}] .array');
 						switch fi.def.type {
-							case F_Int, F_Float, F_String, F_Text: jArray.find("a.usingDefault:last").click();
+							case F_Int, F_Float, F_String, F_Text, F_File: jArray.find("a.usingDefault:last").click();
 							case F_Bool:
 							case F_Color:
 							case F_Enum(enumDefUid):

--- a/src.renderer/ui/modal/panel/EditEntityDefs.hx
+++ b/src.renderer/ui/modal/panel/EditEntityDefs.hx
@@ -86,7 +86,7 @@ class EditEntityDefs extends ui.modal.Panel {
 			// Type picker
 			var w = new ui.modal.Dialog(anchor,"fieldTypes");
 			var types : Array<data.DataTypes.FieldType> = [
-				F_Int, F_Float, F_Bool, F_String, F_Text, F_Enum(null), F_Color, F_Point
+				F_Int, F_Float, F_Bool, F_String, F_Text, F_Enum(null), F_Color, F_Point, F_File
 			];
 			for(type in types) {
 				var b = new J("<button/>");
@@ -558,7 +558,7 @@ class EditEntityDefs extends ui.modal.Panel {
 
 		// Default value
 		switch curField.type {
-			case F_Int, F_Float, F_String, F_Text, F_Point:
+			case F_Int, F_Float, F_String, F_Text, F_Point, F_File:
 				var defInput = jFieldForm.find("input[name=fDef]");
 				if( curField.defaultOverride != null )
 					defInput.val( Std.string( curField.getUntypedDefault() ) );
@@ -573,7 +573,7 @@ class EditEntityDefs extends ui.modal.Panel {
 					defInput.attr("placeholder", switch curField.type {
 						case F_Int: Std.string( curField.iClamp(0) );
 						case F_Float: Std.string( curField.fClamp(0) );
-						case F_String, F_Text: "";
+						case F_String, F_Text, F_File: "";
 						case F_Point: "0"+Const.POINT_SEPARATOR+"0";
 						case F_Bool, F_Color, F_Enum(_): "N/A";
 					});
@@ -701,6 +701,26 @@ class EditEntityDefs extends ui.modal.Panel {
 		input.change( function(ev) {
 			curField.setMax( input.val() );
 			editor.ge.emit( EntityFieldDefChanged(curEntity) );
+		});
+		
+		// Accept file types
+		var input = jFieldForm.find("input[name=acceptTypes]");
+		input.val( curField.acceptFileTypes==null ? "" : curField.acceptFileTypes.join(";") );
+		input.change( function(ev) {
+			curField.setAcceptFileTypes( input.val() );
+			editor.ge.emit( EntityFieldDefChanged(curEntity) );
+		});
+		
+		// File select button
+		var input = jFieldForm.find("button[name=fDefFile]");
+		input.click( function(ev) {
+			dn.electron.Dialogs.open(curField.acceptFileTypes, Editor.ME.getProjectDir(), function( absPath ) {
+				var relPath = Editor.ME.makeRelativeFilePath(absPath);
+				var defInput = jFieldForm.find("input[name=fDef]");
+				defInput.val(relPath);
+				curField.setDefault(relPath);
+				editor.ge.emit( EntityFieldDefChanged(curEntity) );
+			});
 		});
 	}
 


### PR DESCRIPTION
* Added `F_File` type to properties. Acts exactly the same way as `F_String` with extra flavor of file select and extension filters.
* Redid entity instance editor a bit and implemented the stretch bar on the side, allowing user to manually resize it. Because 200 pixels is very little.

Considerations:
* Ideally F_File should validate text field to check that file exists and not an absolute path, but I'm not sure how to implement it.
* Currently stretch size is not retained, and probably should be saved in the editor config?