### PR TITLE
Add JSON Schema and Schema Generator

### DIFF
--- a/doc.hxml
+++ b/doc.hxml
@@ -9,4 +9,4 @@ ldtk/Json.hx
 --next
 -cp src.doc
 -lib deepnightLibs
---macro XmlDocToMarkdown.run("ldtk/Json", "json_doc.xml", "JSON_DOC.md")
+--macro XmlDocToMarkdown.run("ldtk/Json", "json_doc.xml", "JSON_DOC.md", "./schema.json")

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,703 @@
+{
+  "definitions": {
+    "FieldInstance": {
+      "required": [
+        "__identifier",
+        "__type",
+        "__value",
+        "defUid",
+        "realEditorValues"
+      ],
+      "properties": {
+        "__type": {
+          "description": "Type of the field, such as Int, Float, Enum(enum_name), Bool, etc.",
+          "type": "string"
+        },
+        "defUid": {
+          "description": "Reference of the **Field definition** UID",
+          "type": "integer"
+        },
+        "__identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "realEditorValues": { "description": "", "items": {}, "type": "array" },
+        "__value": {
+          "description": "Actual value of the field instance. The value type may vary, depending on `__type` (Integer, Boolean, String etc.)<br/>\t\tIt can also be an `Array` of various types."
+        }
+      }
+    },
+    "EntityInstance": {
+      "required": ["__grid", "__identifier", "defUid", "fieldInstances", "px"],
+      "properties": {
+        "defUid": {
+          "description": "Reference of the **Entity definition** UID",
+          "type": "integer"
+        },
+        "__identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "__tile": {
+          "description": "Optional Tile used to display this entity (it could either be the default Entity tile, or some tile provided by a field value, like an Enum).",
+          "type": "object"
+        },
+        "px": {
+          "description": "Pixel coordinates (`[x,y]` format). Don't forget optional layer offsets, if they exist!",
+          "items": { "type": "integer" },
+          "type": "array"
+        },
+        "__grid": {
+          "description": "Grid-based coordinates (`[x,y]` format)",
+          "items": { "type": "integer" },
+          "type": "array"
+        },
+        "fieldInstances": {
+          "description": "",
+          "items": { "$ref": "#/definitions/FieldInstance" },
+          "type": "array"
+        }
+      }
+    },
+    "Definitions": {
+      "required": ["entities", "enums", "externalEnums", "layers", "tilesets"],
+      "properties": {
+        "tilesets": {
+          "description": "",
+          "items": { "$ref": "#/definitions/TilesetDef" },
+          "type": "array"
+        },
+        "layers": {
+          "description": "",
+          "items": { "$ref": "#/definitions/LayerDef" },
+          "type": "array"
+        },
+        "enums": {
+          "description": "",
+          "items": { "$ref": "#/definitions/EnumDef" },
+          "type": "array"
+        },
+        "entities": {
+          "description": "",
+          "items": { "$ref": "#/definitions/EntityDef" },
+          "type": "array"
+        },
+        "externalEnums": {
+          "description": "Note: external enums are exactly the same as `enums`, except they have a `relPath` to point to an external source file.",
+          "items": { "$ref": "#/definitions/EnumDef" },
+          "type": "array"
+        }
+      }
+    },
+    "AutoRuleDef": {
+      "required": [
+        "active",
+        "breakOnMatch",
+        "chance",
+        "checker",
+        "flipX",
+        "flipY",
+        "pattern",
+        "perlinActive",
+        "perlinOctaves",
+        "perlinScale",
+        "perlinSeed",
+        "pivotX",
+        "pivotY",
+        "size",
+        "tileIds",
+        "tileMode",
+        "uid",
+        "xModulo",
+        "yModulo"
+      ],
+      "properties": {
+        "flipX": {
+          "description": "If TRUE, allow rule to be matched by flipping its pattern horizontally",
+          "type": "boolean"
+        },
+        "pivotX": {
+          "description": "X pivot of a tile stamp (0-1)",
+          "type": "number"
+        },
+        "perlinActive": {
+          "description": "If TRUE, enable Perlin filtering to only apply rule on specific random area",
+          "type": "boolean"
+        },
+        "perlinScale": { "description": "", "type": "number" },
+        "pattern": {
+          "description": "Rule pattern (size x size)",
+          "items": { "type": "integer" },
+          "type": "array"
+        },
+        "checker": {
+          "description": "Checker mode: None, Horizontal or Vertical.",
+          "type": "string"
+        },
+        "perlinOctaves": { "description": "", "type": "number" },
+        "tileIds": {
+          "description": "Array of all the tile IDs. They are used randomly or as stamps, based on `tileMode` value.",
+          "items": { "type": "integer" },
+          "type": "array"
+        },
+        "xModulo": { "description": "X cell coord modulo", "type": "integer" },
+        "size": {
+          "description": "Pattern width & height. Should only be 1,3,5 or 7.",
+          "type": "integer"
+        },
+        "chance": {
+          "description": "Chances for this rule to be applied (0 to 1)",
+          "type": "number"
+        },
+        "breakOnMatch": {
+          "description": "When TRUE, the rule will prevent other rules to be applied in the same cell if it matches (TRUE by default).",
+          "type": "boolean"
+        },
+        "uid": { "description": "Unique Int identifier", "type": "integer" },
+        "perlinSeed": { "description": "", "type": "number" },
+        "tileMode": {
+          "description": "Defines how tileIds array is used",
+          "type": "string"
+        },
+        "flipY": {
+          "description": "If TRUE, allow rule to be matched by flipping its pattern vertically",
+          "type": "boolean"
+        },
+        "pivotY": {
+          "description": "Y pivot of a tile stamp (0-1)",
+          "type": "number"
+        },
+        "yModulo": { "description": "Y cell coord modulo", "type": "integer" },
+        "active": {
+          "description": "If FALSE, the rule effect isn't applied, and no tiles are generated.",
+          "type": "boolean"
+        }
+      }
+    },
+    "FieldDef": {
+      "required": [
+        "__type",
+        "arrayMaxLength",
+        "arrayMinLength",
+        "canBeNull",
+        "defaultOverride",
+        "editorAlwaysShow",
+        "editorDisplayMode",
+        "editorDisplayPos",
+        "identifier",
+        "isArray",
+        "type",
+        "uid"
+      ],
+      "properties": {
+        "acceptFileTypes": {
+          "description": "Optional list of accepted file extensions for FilePath value type. Includes the dot: `.ext`",
+          "items": { "type": "string" },
+          "type": "array"
+        },
+        "editorAlwaysShow": { "description": "", "type": "boolean" },
+        "arrayMinLength": {
+          "description": "Array min length",
+          "type": "integer"
+        },
+        "min": {
+          "description": "Min limit for value, if applicable",
+          "type": "number"
+        },
+        "__type": {
+          "description": "Human readable value type (eg. `Int`, `Float`, `Point`, etc.). If the field is an array, this field will look like `Array<...>` (eg. `Array<Int>`, `Array<Point>` etc.)",
+          "type": "string"
+        },
+        "editorDisplayMode": { "description": "", "type": "string" },
+        "canBeNull": {
+          "description": "TRUE if the value can be null. For arrays, TRUE means it can contain null values (exception: array of Points can't have null values).",
+          "type": "boolean"
+        },
+        "uid": { "description": "Unique Intidentifier", "type": "integer" },
+        "isArray": {
+          "description": "TRUE if the value is an array of multiple values",
+          "type": "boolean"
+        },
+        "editorDisplayPos": { "description": "", "type": "string" },
+        "max": {
+          "description": "Max limit for value, if applicable",
+          "type": "number"
+        },
+        "defaultOverride": {
+          "description": "Default value if selected value is null or invalid.",
+          "type": "string"
+        },
+        "regex": {
+          "description": "Optional regular expression that needs to be matched to accept values. Expected format: `/some_reg_ex/g`, with optional \"i\" flag.",
+          "type": "string"
+        },
+        "type": { "description": "Internal type enum", "type": "string" },
+        "identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "arrayMaxLength": {
+          "description": "Array max length",
+          "type": "integer"
+        }
+      }
+    },
+    "EntityDef": {
+      "required": [
+        "color",
+        "fieldDefs",
+        "height",
+        "identifier",
+        "limitBehavior",
+        "maxPerLevel",
+        "pivotX",
+        "pivotY",
+        "renderMode",
+        "showName",
+        "tileId",
+        "tileRenderMode",
+        "tilesetId",
+        "uid",
+        "width"
+      ],
+      "properties": {
+        "tileId": {
+          "description": "Tile ID used for optional tile display",
+          "type": "integer"
+        },
+        "showName": {
+          "description": "Display entity name in editor",
+          "type": "boolean"
+        },
+        "tilesetId": {
+          "description": "Tileset ID used for optional tile display",
+          "type": "integer"
+        },
+        "pivotX": {
+          "description": "Pivot X coordinate (from 0 to 1.0)",
+          "type": "number"
+        },
+        "color": { "description": "Base entity color", "type": "string" },
+        "fieldDefs": {
+          "description": "Array of field definitions",
+          "items": { "$ref": "#/definitions/FieldDef" },
+          "type": "array"
+        },
+        "tileRenderMode": { "description": "", "type": "string" },
+        "limitBehavior": { "description": "", "type": "string" },
+        "uid": { "description": "Unique Int identifier", "type": "integer" },
+        "height": { "description": "Pixel height", "type": "integer" },
+        "identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "pivotY": {
+          "description": "Pivot Y coordinate (from 0 to 1.0)",
+          "type": "number"
+        },
+        "renderMode": { "description": "", "type": "string" },
+        "maxPerLevel": {
+          "description": "Max instances per level",
+          "type": "integer"
+        },
+        "width": { "description": "Pixel width", "type": "integer" }
+      }
+    },
+    "Project": {
+      "required": [
+        "bgColor",
+        "defaultGridSize",
+        "defaultLevelBgColor",
+        "defaultPivotX",
+        "defaultPivotY",
+        "defs",
+        "exportTiled",
+        "jsonVersion",
+        "levels",
+        "minifyJson",
+        "nextUid",
+        "worldGridHeight",
+        "worldGridWidth",
+        "worldLayout"
+      ],
+      "properties": {
+        "worldGridWidth": {
+          "description": "Width of the world grid in pixels.",
+          "type": "integer"
+        },
+        "defaultLevelBgColor": {
+          "description": "Default background color of levels",
+          "type": "string"
+        },
+        "bgColor": {
+          "description": "Project background color",
+          "type": "string"
+        },
+        "nextUid": { "description": "", "type": "integer" },
+        "defaultPivotY": {
+          "description": "Default Y pivot (0 to 1) for new entities",
+          "type": "number"
+        },
+        "worldGridHeight": {
+          "description": "Height of the world grid in pixels.",
+          "type": "integer"
+        },
+        "defaultGridSize": {
+          "description": "Default grid size for new layers",
+          "type": "integer"
+        },
+        "worldLayout": {
+          "description": "An enum that describes how levels are organized in this project (ie. linearly or in a 2D space). Possible values are: Free, GridVania, LinearHorizontal and LinearVertical;",
+          "type": "string"
+        },
+        "exportTiled": {
+          "description": "If TRUE, a Tiled compatible file will also be generated along with the LDtk JSON file (default is FALSE)",
+          "type": "boolean"
+        },
+        "defs": {
+          "description": "A structure containing all the definitions of this project",
+          "$ref": "#/definitions/Definitions"
+        },
+        "levels": {
+          "description": "All levels. The order of this array is only relevant in `LinearHorizontal` and `linearVertical` world layouts (see `worldLayout` value). Otherwise, you should refer to the `worldX`,`worldY` coordinates of each Level.",
+          "items": { "$ref": "#/definitions/Level" },
+          "type": "array"
+        },
+        "jsonVersion": {
+          "description": "File format version",
+          "type": "string"
+        },
+        "defaultPivotX": {
+          "description": "Default X pivot (0 to 1) for new entities",
+          "type": "number"
+        },
+        "minifyJson": {
+          "description": "If TRUE, the Json is partially minified (no indentation, nor line breaks, default is FALSE)",
+          "type": "boolean"
+        }
+      }
+    },
+    "LayerInstance": {
+      "required": [
+        "__cHei",
+        "__cWid",
+        "__gridSize",
+        "__identifier",
+        "__opacity",
+        "__pxTotalOffsetX",
+        "__pxTotalOffsetY",
+        "__type",
+        "autoLayerTiles",
+        "entityInstances",
+        "gridTiles",
+        "intGrid",
+        "layerDefUid",
+        "levelId",
+        "pxOffsetX",
+        "pxOffsetY",
+        "seed"
+      ],
+      "properties": {
+        "__cHei": { "description": "Grid-based height", "type": "integer" },
+        "pxOffsetX": {
+          "description": "X offset in pixels to render this layer, usually 0 (IMPORTANT: this should be added to the `LayerDef` optional offset, see `__pxTotalOffsetX`)",
+          "type": "integer"
+        },
+        "__tilesetRelPath": {
+          "description": "The relative path to corresponding Tileset, if any.",
+          "type": "string"
+        },
+        "levelId": {
+          "description": "Reference to the UID of the level containing this layer instance",
+          "type": "integer"
+        },
+        "__type": {
+          "description": "Layer type (possible values: IntGrid, Entities, Tiles or AutoLayer)",
+          "type": "string"
+        },
+        "autoLayerTiles": {
+          "description": "An array containing all tiles generated by Auto-layer rules. The array is already sorted in display order (ie. 1st tile is beneath 2nd, which is beneath 3rd etc.).<br/><br/>\t\tNote: if multiple tiles are stacked in the same cell as the result of different rules, all tiles behind opaque ones will be discarded.",
+          "items": { "$ref": "#/definitions/Tile" },
+          "type": "array"
+        },
+        "__identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "__gridSize": { "description": "Grid size", "type": "integer" },
+        "__pxTotalOffsetY": {
+          "description": "Total layer Y pixel offset, including both instance and definition offsets.",
+          "type": "integer"
+        },
+        "entityInstances": {
+          "description": "",
+          "items": { "$ref": "#/definitions/EntityInstance" },
+          "type": "array"
+        },
+        "__opacity": {
+          "description": "Layer opacity as Float [0-1]",
+          "type": "number"
+        },
+        "seed": {
+          "description": "Random seed used for Auto-Layers rendering",
+          "type": "integer"
+        },
+        "layerDefUid": {
+          "description": "Reference the Layer definition UID",
+          "type": "integer"
+        },
+        "__pxTotalOffsetX": {
+          "description": "Total layer X pixel offset, including both instance and definition offsets.",
+          "type": "integer"
+        },
+        "__cWid": { "description": "Grid-based width", "type": "integer" },
+        "pxOffsetY": {
+          "description": "Y offset in pixels to render this layer, usually 0 (IMPORTANT: this should be added to the `LayerDef` optional offset, see `__pxTotalOffsetY`)",
+          "type": "integer"
+        },
+        "__tilesetDefUid": {
+          "description": "The definition UID of corresponding Tileset, if any.",
+          "type": "integer"
+        },
+        "gridTiles": {
+          "description": "",
+          "items": { "$ref": "#/definitions/Tile" },
+          "type": "array"
+        },
+        "intGrid": {
+          "description": "",
+          "items": { "type": "object" },
+          "type": "array"
+        }
+      }
+    },
+    "TilesetDef": {
+      "required": [
+        "identifier",
+        "padding",
+        "pxHei",
+        "pxWid",
+        "relPath",
+        "savedSelections",
+        "spacing",
+        "tileGridSize",
+        "uid"
+      ],
+      "properties": {
+        "cachedPixelData": {
+          "description": "The following data is used internally for various optimizations. It's always synced with source image changes.",
+          "type": "object"
+        },
+        "pxHei": { "description": "Image height in pixels", "type": "integer" },
+        "uid": { "description": "Unique Intidentifier", "type": "integer" },
+        "padding": {
+          "description": "Distance in pixels from image borders",
+          "type": "integer"
+        },
+        "pxWid": { "description": "Image width in pixels", "type": "integer" },
+        "spacing": {
+          "description": "Space in pixels between all tiles",
+          "type": "integer"
+        },
+        "identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "savedSelections": {
+          "description": "Array of group of tiles selections, only meant to be used in the editor",
+          "items": { "type": "object" },
+          "type": "array"
+        },
+        "relPath": {
+          "description": "Path to the source file, relative to the current project JSON file",
+          "type": "string"
+        },
+        "tileGridSize": { "description": "", "type": "integer" }
+      }
+    },
+    "Tile": {
+      "required": ["d", "f", "px", "src", "t"],
+      "properties": {
+        "t": {
+          "description": "The *Tile ID* in the corresponding tileset.",
+          "type": "integer"
+        },
+        "d": {
+          "description": "Internal data used by the editor.<br/>\t\tFor auto-layer tiles: `[ruleId, coordId]`.<br/>\t\tFor tile-layer tiles: `[coordId]`.",
+          "items": { "type": "integer" },
+          "type": "array"
+        },
+        "px": {
+          "description": "Pixel coordinates of the tile in the **layer** (`[x,y]` format). Don't forget optional layer offsets, if they exist!",
+          "items": { "type": "integer" },
+          "type": "array"
+        },
+        "f": {
+          "description": "\"Flip bits\", a 2-bits integer to represent the mirror transformations of the tile.<br/>\t\t - Bit 0 = X flip<br/>\t\t - Bit 1 = Y flip<br/>\t\t Examples: f=0 (no flip), f=1 (X flip only), f=2 (Y flip only), f=3 (both flips)",
+          "type": "integer"
+        },
+        "src": {
+          "description": "Pixel coordinates of the tile in the **tileset** (`[x,y]` format)",
+          "items": { "type": "integer" },
+          "type": "array"
+        }
+      }
+    },
+    "LayerDef": {
+      "required": [
+        "__type",
+        "autoRuleGroups",
+        "autoSourceLayerDefUid",
+        "autoTilesetDefUid",
+        "displayOpacity",
+        "gridSize",
+        "identifier",
+        "intGridValues",
+        "pxOffsetX",
+        "pxOffsetY",
+        "tilePivotX",
+        "tilePivotY",
+        "tilesetDefUid",
+        "type",
+        "uid"
+      ],
+      "properties": {
+        "pxOffsetX": {
+          "description": "X offset of the layer, in pixels (IMPORTANT: this should be added to the `LayerInstance` optional offset)",
+          "type": "integer"
+        },
+        "tilePivotX": {
+          "description": "If the tiles are smaller or larger than the layer grid, the pivot value will be used to position the tile relatively its grid cell.",
+          "type": "number"
+        },
+        "displayOpacity": {
+          "description": "Opacity of the layer (0 to 1.0)",
+          "type": "number"
+        },
+        "__type": {
+          "description": "Type of the layer (*IntGrid, Entities, Tiles or AutoLayer*)",
+          "type": "string"
+        },
+        "tilesetDefUid": {
+          "description": "Reference to the Tileset UID being used by this tile layer",
+          "type": "integer"
+        },
+        "autoSourceLayerDefUid": { "description": "", "type": "integer" },
+        "autoTilesetDefUid": {
+          "description": "Reference to the Tileset UID being used by this auto-layer rules",
+          "type": "integer"
+        },
+        "uid": { "description": "Unique Int identifier", "type": "integer" },
+        "intGridValues": {
+          "description": "",
+          "items": { "type": "object" },
+          "type": "array"
+        },
+        "autoRuleGroups": {
+          "description": "Contains all the auto-layer rule definitions.",
+          "items": { "type": "object" },
+          "type": "array"
+        },
+        "type": {
+          "description": "Type of the layer as Haxe Enum",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "pxOffsetY": {
+          "description": "Y offset of the layer, in pixels (IMPORTANT: this should be added to the `LayerInstance` optional offset)",
+          "type": "integer"
+        },
+        "tilePivotY": {
+          "description": "If the tiles are smaller or larger than the layer grid, the pivot value will be used to position the tile relatively its grid cell.",
+          "type": "number"
+        },
+        "gridSize": {
+          "description": "Width and height of the grid in pixels",
+          "type": "integer"
+        }
+      }
+    },
+    "Level": {
+      "required": [
+        "__bgColor",
+        "__neighbours",
+        "identifier",
+        "layerInstances",
+        "pxHei",
+        "pxWid",
+        "uid",
+        "worldX",
+        "worldY"
+      ],
+      "properties": {
+        "__neighbours": {
+          "description": "An array listing all other levels touching this one on the world map. The `dir` is a single lowercase character tipping on the level location (`n`orth, `s`outh, `w`est, `e`ast). In \"linear\" world layouts, this array is populated with previous/next levels in array, and `dir` depends on the linear horizontal/vertical layout.",
+          "items": { "type": "object" },
+          "type": "array"
+        },
+        "__bgColor": {
+          "description": "Background color of the level (same as `bgColor`, except the default value is automatically used here if its value is `null`)",
+          "type": "string"
+        },
+        "worldX": {
+          "description": "World X coordinate in pixels",
+          "type": "integer"
+        },
+        "bgColor": {
+          "description": "Background color of the level. If `null`, the project `defaultLevelBgColor` should be used.",
+          "type": "string"
+        },
+        "pxHei": {
+          "description": "Height of the level in pixels",
+          "type": "integer"
+        },
+        "worldY": {
+          "description": "World Y coordinate in pixels",
+          "type": "integer"
+        },
+        "uid": { "description": "Unique Int identifier", "type": "integer" },
+        "pxWid": {
+          "description": "Width of the level in pixels",
+          "type": "integer"
+        },
+        "identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        },
+        "layerInstances": {
+          "description": "",
+          "items": { "$ref": "#/definitions/LayerInstance" },
+          "type": "array"
+        }
+      }
+    },
+    "EnumDef": {
+      "required": ["identifier", "uid", "values"],
+      "properties": {
+        "externalFileChecksum": { "description": "", "type": "string" },
+        "externalRelPath": {
+          "description": "Relative path to the external file providing this Enum",
+          "type": "string"
+        },
+        "uid": { "description": "Unique Int identifier", "type": "integer" },
+        "values": {
+          "description": "All possible enum values, with their optional Tile infos.",
+          "items": { "type": "object" },
+          "type": "array"
+        },
+        "iconTilesetUid": {
+          "description": "Tileset UID if provided",
+          "type": "integer"
+        },
+        "identifier": {
+          "description": "Unique String identifier",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/Project"
+}


### PR DESCRIPTION
Here's a somewhat messy start to a JSON schema generator. I used it to quickly generate Rust structs using `quicktype`, but it's worth noting that I wasn't completely satisfied with the generated structs and modified them manually afterwards. I'm not sure if that is because of quicktypes rust generator implementation or if it is because the JSON schema is not as strictly typed or correctly structured as it should be.

Either way, here it is if it is useful. I probably won't have time myself to clean it up much if it needs improvement, but even if it is just useful as a base for somebody who wants to do a final iteration.

Also, I manually formatted the schema.json for readability using VSCode after running the command to generate it. That may or may not be something we want to do.