### PR TITLE
A new point display mode for unconnected points

### DIFF
--- a/docs/JSON_DOC.md
+++ b/docs/JSON_DOC.md
@@ -253,7 +253,7 @@ Value | Type | Description
 `uid`<br/><sup class="internal">*Internal editor data*</sup> | Int | Unique Intidentifier
 `editorAlwaysShow`<br/><sup class="internal">*Internal editor data*</sup> | Bool | 
 `editorCutLongValues`<br/><sup class="internal">*Internal editor data*</sup><br/> ![Generic badge](https://img.shields.io/badge/Added_0.8.0-green.svg)  | Bool | 
-`editorDisplayMode`<br/><sup class="internal">*Internal editor data*</sup> | Enum | Possible values: `Hidden`, `ValueOnly`, `NameAndValue`, `EntityTile`, `PointStar`, `PointPath`, `PointPathLoop`, `RadiusPx`, `RadiusGrid`
+`editorDisplayMode`<br/><sup class="internal">*Internal editor data*</sup> | Enum | Possible values: `Hidden`, `ValueOnly`, `NameAndValue`, `EntityTile`, `Points`, `PointStar`, `PointPath`, `PointPathLoop`, `RadiusPx`, `RadiusGrid`
 `editorDisplayPos`<br/><sup class="internal">*Internal editor data*</sup> | Enum | Possible values: `Above`, `Center`, `Beneath`
 `textLangageMode`<br/><sup class="internal">*Internal editor data*</sup> | Enum&nbsp;*(can&nbsp;be&nbsp;`null`)* | Possible values: &lt;`null`&gt;, `LangPython`, `LangRuby`, `LangJS`, `LangLua`, `LangC`, `LangHaxe`, `LangMarkdown`, `LangJson`, `LangXml`
 

--- a/docs/JSON_SCHEMA.json
+++ b/docs/JSON_SCHEMA.json
@@ -608,12 +608,13 @@
 					]
 				},
 				"editorDisplayMode": {
-					"description": "Possible values: `Hidden`, `ValueOnly`, `NameAndValue`, `EntityTile`, `PointStar`, `PointPath`, `PointPathLoop`, `RadiusPx`, `RadiusGrid`",
+					"description": "Possible values: `Hidden`, `ValueOnly`, `NameAndValue`, `EntityTile`, `Points`, `PointStar`, `PointPath`, `PointPathLoop`, `RadiusPx`, `RadiusGrid`",
 					"enum": [
 						"Hidden",
 						"ValueOnly",
 						"NameAndValue",
 						"EntityTile",
+						"Points",
 						"PointStar",
 						"PointPath",
 						"PointPathLoop",

--- a/src/electron.renderer/data/Level.hx
+++ b/src/electron.renderer/data/Level.hx
@@ -479,6 +479,7 @@ class Level {
 
 					case Hidden:
 					case EntityTile:
+					case Points:
 					case PointStar:
 					case PointPath, PointPathLoop:
 					case RadiusPx:

--- a/src/electron.renderer/display/FieldInstanceRender.hx
+++ b/src/electron.renderer/display/FieldInstanceRender.hx
@@ -149,7 +149,7 @@ class FieldInstanceRender {
 
 			case EntityTile:
 
-			case PointStar, PointPath, PointPathLoop:
+			case Points, PointStar, PointPath, PointPathLoop:
 				switch ctx {
 					case EntityCtx(g, ei, ld):
 						var fx = ei.getPointOriginX(ld) - ei.x;
@@ -165,7 +165,9 @@ class FieldInstanceRender {
 
 							var tx = M.round( (pt.cx+0.5)*ld.gridSize - ei.x );
 							var ty = M.round( (pt.cy+0.5)*ld.gridSize - ei.y );
-							renderDashedLine(g, fx,fy, tx,ty, 3);
+							if( fd.editorDisplayMode!=Points ) {
+								renderDashedLine(g, fx,fy, tx,ty, 3);
+							}
 							g.drawRect( tx-2, ty-2, 4, 4 );
 
 							if( fd.editorDisplayMode==PointPath || fd.editorDisplayMode==PointPathLoop ) {

--- a/src/electron.renderer/ui/FieldDefsForm.hx
+++ b/src/electron.renderer/ui/FieldDefsForm.hx
@@ -334,6 +334,7 @@ class FieldDefsForm {
 						curField.isArray
 						? L.t._('Show "::name::=[...values...]"', { name:curField.identifier })
 						: L.t._('Show "::name::=..."', { name:curField.identifier });
+					case Points: curField.isArray ? L.t._("Show points") : L.t._("Show point");
 					case PointStar: curField.isArray ? L.t._("Show star of points") : L.t._("Show point");
 					case PointPath: L.t._("Show path of points");
 					case PointPathLoop: L.t._("Show path of points (looping)");
@@ -352,7 +353,7 @@ class FieldDefsForm {
 					case EntityTile:
 						curField.isEnum() && fieldParent==FP_Entity;
 
-					case PointStar:
+					case Points, PointStar:
 						curField.type==F_Point && fieldParent==FP_Entity;
 
 					case PointPath, PointPathLoop:
@@ -385,7 +386,7 @@ class FieldDefsForm {
 			case ValueOnly, NameAndValue:
 				i.setEnabled(true);
 
-			case Hidden, PointStar, PointPath, PointPathLoop, RadiusPx, RadiusGrid, EntityTile:
+			case Hidden, Points, PointStar, PointPath, PointPathLoop, RadiusPx, RadiusGrid, EntityTile:
 				i.setEnabled(false);
 		}
 		i.onChange = onFieldChange;

--- a/src/electron.renderer/ui/FieldInstancesForm.hx
+++ b/src/electron.renderer/ui/FieldInstancesForm.hx
@@ -577,7 +577,7 @@ class FieldInstancesForm {
 				var jArrayInputs = new J('<ul class="values"/>');
 				jArrayInputs.appendTo(jArray);
 
-				if( fi.def.type==F_Point && ( fi.def.editorDisplayMode==PointPath || fi.def.editorDisplayMode==PointStar ) ) {
+				if( fi.def.type==F_Point && ( fi.def.editorDisplayMode==Points || fi.def.editorDisplayMode==PointPath || fi.def.editorDisplayMode==PointStar ) ) {
 					// No points listing if displayed as path
 					var jLi = new J('<li class="compact"/>');
 					var vals = [];


### PR DESCRIPTION
A user may want to add an array of points to an entity where the points have no directional relationship to eachother. This would make the path / star display modes unsuitable. An example of this would be a series of points in the world which an entity will investigate in a random order. This PR introduces a new `Points` display mode, which displays the point array as a series of unconnected points.

![image](https://user-images.githubusercontent.com/7504843/109725352-e9abba80-7ba8-11eb-9f50-b64a0f1d3f3e.png)

Points:
![image](https://user-images.githubusercontent.com/7504843/109725698-6c347a00-7ba9-11eb-970d-3e7798cc9911.png)

Star of points:
![image](https://user-images.githubusercontent.com/7504843/109725644-5aeb6d80-7ba9-11eb-9724-2216cf817014.png)

Path of points;
![image](https://user-images.githubusercontent.com/7504843/109725601-49a26100-7ba9-11eb-9e70-1fed5cc5765b.png)

Path of points (looping):
![image](https://user-images.githubusercontent.com/7504843/109725522-2e375600-7ba9-11eb-8689-485dde367cbb.png)

Let me know what you think! Cheers.