### PR TITLE
Fix regex not null when it's an empty string

### DIFF
--- a/src/electron.renderer/data/def/FieldDef.hx
+++ b/src/electron.renderer/data/def/FieldDef.hx
@@ -444,7 +444,7 @@ class FieldDef {
 	}
 
 	public function setRegexContent(raw:String) {
-		if( raw==null )
+		if( raw==null || raw=="")
 			regex = null;
 		else
 			regex = '/$raw/${getRegexFlagsStr()}';


### PR DESCRIPTION
Found an annoying crash when you set the `Regex Check` string to anything, validate, and then set it to an empty string and validate again.
That crash will happen on every entity instances of the type you messed up.
`regex` should be set to `null` but it's set to `"//g"` and causes a crash whenever you change the corresponding property on the entity.

```jsonc
"fieldDefs": [
	{
		"identifier": "String",
		// ...
		"regex": "//g", // This should be null instead
		// ...
	}
]
```

This simple PR should take care of that.

Steps to reproduce without the fix:
* Create a new project entity
* Add a String field
* Set regex check to anything and validate by pressing enter for example
* Set regex check to an empty string (remove every characters) and validate
* Put an instance of that entity in a level
* Change the string value and it should crash when you validate