### PR TITLE
Add missing mainWindow.show() call in debug environment

### DIFF
--- a/src/electron.main/ElectronMain.hx
+++ b/src/electron.main/ElectronMain.hx
@@ -99,6 +99,7 @@ class ElectronMain {
 		var p = mainWindow.loadFile('assets/app.html');
 		#if debug
 			// Show immediately
+			mainWindow.show();
 			mainWindow.maximize();
 			p.then( (_)->{}, (_)->_fileNotFound("app.html") );
 		#else


### PR DESCRIPTION
In https://github.com/deepnight/ldtk/pull/109, `mainWindow.show()` is added to fix window visibility issue on MacOS.

This PR add the same call to debug mode