### PR TITLE
Fix build error on Apple M1 by upgrade electron to 12.0.7

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
 		"sortablejs": "^1.10.2"
 	},
 	"devDependencies": {
-		"electron": "^10.1.5",
+		"electron": "^12.0.7",
 		"electron-builder": "^22.9.1"
 	},
 	"build": {

--- a/src/electron.main/ElectronMain.hx
+++ b/src/electron.main/ElectronMain.hx
@@ -73,7 +73,7 @@ class ElectronMain {
 
 		// Init window
 		mainWindow = new electron.main.BrowserWindow({
-			webPreferences: { nodeIntegration:true },
+			webPreferences: { nodeIntegration:true, contextIsolation: false },
 			fullscreenable: true,
 			show: false,
 			title: "LDtk",


### PR DESCRIPTION
When building on Apple M1, the following error occurs due to there's no arm64 build for electron 10.

```
$ npm i
npm ERR! code 1
npm ERR! path /Users/poga/projects/ldtk/app/node_modules/electron
npm ERR! command failed
npm ERR! command sh -c node install.js
npm ERR! HTTPError: Response code 404 (Not Found) for https://github.com/electron/electron/releases/download/v10.4.5/electron-v10.4.5-darwin-arm64.zip
npm ERR!     at EventEmitter.<anonymous> (/Users/poga/projects/ldtk/app/node_modules/got/source/as-stream.js:35:24)
npm ERR!     at EventEmitter.emit (node:events:378:20)
npm ERR!     at module.exports (/Users/poga/projects/ldtk/app/node_modules/got/source/get-response.js:22:10)
npm ERR!     at ClientRequest.handleResponse (/Users/poga/projects/ldtk/app/node_modules/got/source/request-as-event-emitter.js:155:5)
npm ERR!     at Object.onceWrapper (node:events:485:26)
npm ERR!     at ClientRequest.emit (node:events:390:22)
npm ERR!     at ClientRequest.origin.emit (/Users/poga/projects/ldtk/app/node_modules/@szmarczak/http-timer/source/index.js:37:11)
npm ERR!     at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:636:27)
npm ERR!     at HTTPParser.parserOnHeadersComplete (node:_http_common:129:17)
npm ERR!     at TLSSocket.socketOnData (node:_http_client:502:22)

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/poga/.npm/_logs/2021-05-08T09_28_35_997Z-debug.log
```

Also, ldtk depends on https://github.com/tong/hxelectron and it's already upgraded to `12.0.7`.

This PR upgrade electron to `12.0.7` and fixed a breaking change mentioned in [electron 12 release note](https://www.electronjs.org/releases/stable?version=12&page=2#breaking-changes-1200)