### PR TITLE
add lix pm, remove dep to install Haxe and Haxelibs manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ res/.tmp
 .vscode/settings.json
 
 app/*.log
+package-lock.json
 app/package-lock.json
 app/settings
 app/redist
@@ -26,3 +27,4 @@ app/assets/js/*.map
 art/export_appElements
 
 tests/_doNotShare
+node_modules

--- a/.haxerc
+++ b/.haxerc
@@ -1,0 +1,4 @@
+{
+  "version": "4.2.0",
+  "resolveLibs": "scoped"
+}

--- a/README.md
+++ b/README.md
@@ -17,29 +17,11 @@ Visit [LDtk.io](https://ldtk.io) to get latest version.
 
 ## Requirements
 
- - **[Haxe compiler](https://haxe.org)**: you need an up-to-date and working Haxe install  to build LDtk.
  - **[NPM](https://www.npmjs.com/)**: this package manager is used for various install and packaging scripts
-
-### Installing Haxe libs
-
-Install required haxe libs:
-```
-haxelib git heaps https://github.com/deepnight/heaps.git
-
-haxelib git hxnodejs https://github.com/HaxeFoundation/hxnodejs.git
-
-haxelib git electron https://github.com/tong/hxelectron.git
-
-haxelib git deepnightLibs https://github.com/deepnight/deepnightLibs.git
-
-haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git
-
-haxelib git castle https://github.com/ncannasse/castle.git
-```
 
 ### Installing Node dependencies
 
-Run the following command in the `app` folder:
+Run the following command:
 ```
 npm i
 ```
@@ -68,12 +50,6 @@ If you want to try a future version of LDtk, you can checkout branches named `de
 
 **IMPORTANT**:
  - these *dev* branches might be unstables, or even broken. Therefore, it's not recommended to use, unless you plan to add or fix something on LDtk.
- - because *dev* branches might change quickly, you will need to update haxelibs often.
- - you will need to switch the *LDtk haxe API* to the **same** branch as LDtk repo. (adapt the branch name below accordingly):
-
-```
-haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git dev-0.6.0
-```
 
 ## Running
 

--- a/haxe_libraries/ase.hxml
+++ b/haxe_libraries/ase.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "haxelib:/ase#1.1.1" into ase/1.1.1/haxelib
+-cp ${HAXE_LIBCACHE}/ase/1.1.1/haxelib/src
+-D ase=1.1.1

--- a/haxe_libraries/castle.hxml
+++ b/haxe_libraries/castle.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "gh://github.com/ncannasse/castle#53d6daf5fade1505a6abf7b407e2332f4f77e2cf" into castle/1.6.1/github/53d6daf5fade1505a6abf7b407e2332f4f77e2cf
+-cp ${HAXE_LIBCACHE}/castle/1.6.1/github/53d6daf5fade1505a6abf7b407e2332f4f77e2cf/
+-D castle=1.6.1

--- a/haxe_libraries/deepnightLibs.hxml
+++ b/haxe_libraries/deepnightLibs.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "gh://github.com/deepnight/deepnightLibs#ebab3786f1f58f0c11f7cdc25f22f798e6b9a9b3" into deepnightLibs/1.0.59/github/ebab3786f1f58f0c11f7cdc25f22f798e6b9a9b3
+-cp ${HAXE_LIBCACHE}/deepnightLibs/1.0.59/github/ebab3786f1f58f0c11f7cdc25f22f798e6b9a9b3/src/
+-D deepnightLibs=1.0.59

--- a/haxe_libraries/electron.hxml
+++ b/haxe_libraries/electron.hxml
@@ -1,0 +1,4 @@
+# @install: lix --silent download "gh://github.com/tong/hxelectron#628364b950f14a87e4c6668fd22fa04824c473b5" into electron/12.0.9/github/628364b950f14a87e4c6668fd22fa04824c473b5
+-lib hxnodejs
+-cp ${HAXE_LIBCACHE}/electron/12.0.9/github/628364b950f14a87e4c6668fd22fa04824c473b5/src
+-D electron=12.0.9

--- a/haxe_libraries/format.hxml
+++ b/haxe_libraries/format.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "haxelib:/format#3.5.0" into format/3.5.0/haxelib
+-cp ${HAXE_LIBCACHE}/format/3.5.0/haxelib/
+-D format=3.5.0

--- a/haxe_libraries/heaps-aseprite.hxml
+++ b/haxe_libraries/heaps-aseprite.hxml
@@ -1,0 +1,6 @@
+# @install: lix --silent download "gh://github.com/deepnight/heaps-aseprite#738f0480976903343b8f6f8aa354a20099588f51" into heaps-aseprite/0.0.4/github/738f0480976903343b8f6f8aa354a20099588f51
+-lib ase
+-cp ${HAXE_LIBCACHE}/heaps-aseprite/0.0.4/github/738f0480976903343b8f6f8aa354a20099588f51/
+-D heaps-aseprite=0.0.4
+# Adds .aseprite file handling to hxd.res.Config
+--macro aseprite.Macros.init()

--- a/haxe_libraries/heaps.hxml
+++ b/haxe_libraries/heaps.hxml
@@ -1,0 +1,4 @@
+# @install: lix --silent download "gh://github.com/deepnight/heaps#7c578975b47bc71dd5212edba40298a6cf0aeab8" into heaps/1.9.1/github/7c578975b47bc71dd5212edba40298a6cf0aeab8
+-lib format
+-cp ${HAXE_LIBCACHE}/heaps/1.9.1/github/7c578975b47bc71dd5212edba40298a6cf0aeab8/
+-D heaps=1.9.1

--- a/haxe_libraries/hxnodejs.hxml
+++ b/haxe_libraries/hxnodejs.hxml
@@ -1,0 +1,7 @@
+# @install: lix --silent download "gh://github.com/HaxeFoundation/hxnodejs#d2d871c5b4d4589fa4ccb6e2031f982e172f8860" into hxnodejs/12.1.0/github/d2d871c5b4d4589fa4ccb6e2031f982e172f8860
+-cp ${HAXE_LIBCACHE}/hxnodejs/12.1.0/github/d2d871c5b4d4589fa4ccb6e2031f982e172f8860/src
+-D hxnodejs=12.1.0
+--macro allowPackage('sys')
+# should behave like other target defines and not be defined in macro context
+--macro define('nodejs')
+--macro _internal.SuppressDeprecated.run()

--- a/haxe_libraries/ldtk-haxe-api.hxml
+++ b/haxe_libraries/ldtk-haxe-api.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "gh://github.com/deepnight/ldtk-haxe-api#1ea2a42f71371d4c983bc922aa2b81b4209e8ced" into ldtk-haxe-api/0.9.3-rc.1/github/1ea2a42f71371d4c983bc922aa2b81b4209e8ced
+-cp ${HAXE_LIBCACHE}/ldtk-haxe-api/0.9.3-rc.1/github/1ea2a42f71371d4c983bc922aa2b81b4209e8ced/src/
+-D ldtk-haxe-api=0.9.3-rc.1

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "ldtk",
+	"productName": "LDtk",
+	"author": "Sebastien Benard",
+	"description": "2D level editor",
+	"scripts": {
+		"start": "cd app && npm run start",
+		"compile": "haxe main.hxml && haxe renderer.hxml",
+		"doc": "haxe doc.hxml",
+		"pack-prepare": "cd app && npm run pack-prepare",
+		"pack-test": "cd app && npm run pack-test",
+		"pack-win": "cd app && npm run pack-win",
+		"pack-macos": "cd app && npm run pack-macos",
+		"pack-linux-x86": "cd app && npm run pack-linux-x86",
+		"pack-linux-arm64": "cd app && npm run pack-linux-arm64",
+		"publish-github": "cd app && npm run publish-github",
+		"publish-itchio": "cd app && publish-itchio",
+		"quicktype": "cd app && npm run quicktype",
+		"qt-cs": "cd app && npm run qt-cs",
+		"qt-js": "cd app && npm run qt-js",
+		"qt-py": "cd app && npm run qt-py",
+		"qt-rs": "cd app && npm run qt-rs",
+		"qt-go": "cd app && npm run qt-go",
+		"qt-cpp": "cd app && npm run qt-cpp",
+		"postinstall": "lix download && cd app && npm i"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/deepnight/ldtk.git"
+	},
+	"devDependencies": {
+		"lix": "^15.9.1"
+	}
+}


### PR DESCRIPTION
Should help with ease of installation, as now there is no need to manually switch directories and install commands manually from the readme.