### PR TITLE
Stop entity chain via right click

### DIFF
--- a/src/electron.renderer/tool/lt/EntityTool.hx
+++ b/src/electron.renderer/tool/lt/EntityTool.hx
@@ -90,6 +90,9 @@ class EntityTool extends tool.LayerTool<Int> {
 	override function startUsing(ev:hxd.Event, m:Coords) {
 		super.startUsing(ev,m);
 
+		if(ev.button==1)
+			clearPrevAutoRefEntity();
+
 		var ge = editor.getGenericLevelElementAt(m);
 		switch ge {
 			case Entity(_) if( ev.button==0 ):


### PR DESCRIPTION
Found that you couldn't stop an entity chain in 0.10 without deleting an entitiy. This 2-liner lets you stop a chain by right clicking. When you left click after this, you start a new chain. This lets you create multiple, seperate chains of entities quickly.