### PR TITLE
Fix parsing error when using embedded atlas LdtkIcons

### DIFF
--- a/docs/JSON_SCHEMA.json
+++ b/docs/JSON_SCHEMA.json
@@ -1871,7 +1871,8 @@
 				"relPath": {
 					"description": "Path to the source file, relative to the current project JSON file",
 					"type": [
-						"string"
+						"string",
+						"null"
 					]
 				},
 				"tileGridSize": {


### PR DESCRIPTION
When using LdtkIcons the field `relPath` contains a `null` which is currently not allowed in the schema.

Made relPath optional 