### PR TITLE
Generate a minimal Schema for quicktype

### DIFF
--- a/doc.hxml
+++ b/doc.hxml
@@ -9,4 +9,4 @@ ldtk/Json.hx
 --next
 -cp src/docGenerator
 -lib deepnightLibs
---macro DocGenerator.run("ldtk/Json", "docs/json_doc.xml", "docs/JSON_DOC.md", "docs/JSON_SCHEMA.json")
+--macro DocGenerator.run("ldtk/Json", "docs/json_doc.xml", "docs/JSON_DOC.md", "docs/JSON_SCHEMA.json", "docs/MINIMAL_JSON_SCHEMA.json")

--- a/docs/MINIMAL_JSON_SCHEMA.json
+++ b/docs/MINIMAL_JSON_SCHEMA.json
@@ -1,0 +1,1648 @@
+{
+	"description": "This file is a JSON schema of files created by LDtk level editor (https://ldtk.io).",
+	"title": "LDtk 1.0.0 JSON schema",
+	"$schema": "https://json-schema.org/draft-07/schema#",
+	"$ref": "#/LdtkJsonRoot",
+	"version": "1.0.0",
+	"LdtkJsonRoot": {
+		"description": "This is the root of any Project JSON file. It contains:  - the project settings, - an array of levels, - a group of definitions (that can probably be safely ignored for most users).",
+		"title": "LDtk Json root",
+		"required": [
+			"bgColor",
+			"defs",
+			"externalLevels",
+			"jsonVersion",
+			"levels",
+			"worlds"
+		],
+		"properties": {
+			"worldGridWidth": {
+				"description": "**WARNING**: this field will move to the `worlds` array after the \"multi-worlds\" update. It will then be `null`. You can enable the Multi-worlds advanced project option to enable the change immediately.<br/><br/>  Width of the world grid in pixels.",
+				"type": [
+					"integer",
+					"null"
+				]
+			},
+			"bgColor": {
+				"description": "Project background color",
+				"type": [
+					"string"
+				]
+			},
+			"worlds": {
+				"description": "This array is not used yet in current LDtk version (so, for now, it's always empty).<br/><br/>In a later update, it will be possible to have multiple Worlds in a single project, each containing multiple Levels.<br/><br/>What will change when \"Multiple worlds\" support will be added to LDtk:<br/><br/> - in current version, a LDtk project file can only contain a single world with multiple levels in it. In this case, levels and world layout related settings are stored in the root of the JSON.<br/> - after the \"Multiple worlds\" update, there will be a `worlds` array in root, each world containing levels and layout settings. Basically, it's pretty much only about moving the `levels` array to the `worlds` array, along with world layout related values (eg. `worldGridWidth` etc).<br/><br/>If you want to start supporting this future update easily, please refer to this documentation: https://github.com/deepnight/ldtk/issues/231",
+				"items": {
+					"$ref": "#/otherTypes/World"
+				},
+				"type": [
+					"array"
+				]
+			},
+			"worldGridHeight": {
+				"description": "**WARNING**: this field will move to the `worlds` array after the \"multi-worlds\" update. It will then be `null`. You can enable the Multi-worlds advanced project option to enable the change immediately.<br/><br/>  Height of the world grid in pixels.",
+				"type": [
+					"integer",
+					"null"
+				]
+			},
+			"worldLayout": {
+				"description": "**WARNING**: this field will move to the `worlds` array after the \"multi-worlds\" update. It will then be `null`. You can enable the Multi-worlds advanced project option to enable the change immediately.<br/><br/>  An enum that describes how levels are organized in this project (ie. linearly or in a 2D space). Possible values: &lt;`null`&gt;, `Free`, `GridVania`, `LinearHorizontal`, `LinearVertical`, `null`",
+				"enum": [
+					"Free",
+					"GridVania",
+					"LinearHorizontal",
+					"LinearVertical",
+					null,
+					null
+				]
+			},
+			"__FORCED_REFS": {
+				"description": "This object is not actually used by LDtk. It ONLY exists to force explicit references to all types, to make sure QuickType finds them and integrate all of them. Otherwise, Quicktype will drop types that are not explicitely used.",
+				"properties": {
+					"TilesetRect": {
+						"$ref": "#/otherTypes/TilesetRect"
+					},
+					"FieldInstance": {
+						"$ref": "#/otherTypes/FieldInstance"
+					},
+					"EntityInstance": {
+						"$ref": "#/otherTypes/EntityInstance"
+					},
+					"Definitions": {
+						"$ref": "#/otherTypes/Definitions"
+					},
+					"EnumTagValue": {
+						"$ref": "#/otherTypes/EnumTagValue"
+					},
+					"AutoRuleDef": {
+						"$ref": "#/otherTypes/AutoRuleDef"
+					},
+					"FieldDef": {
+						"$ref": "#/otherTypes/FieldDef"
+					},
+					"EntityDef": {
+						"$ref": "#/otherTypes/EntityDef"
+					},
+					"AutoLayerRuleGroup": {
+						"$ref": "#/otherTypes/AutoLayerRuleGroup"
+					},
+					"IntGridValueInstance": {
+						"$ref": "#/otherTypes/IntGridValueInstance"
+					},
+					"NeighbourLevel": {
+						"$ref": "#/otherTypes/NeighbourLevel"
+					},
+					"LayerInstance": {
+						"$ref": "#/otherTypes/LayerInstance"
+					},
+					"World": {
+						"$ref": "#/otherTypes/World"
+					},
+					"EntityReferenceInfos": {
+						"$ref": "#/otherTypes/EntityReferenceInfos"
+					},
+					"TileCustomMetadata": {
+						"$ref": "#/otherTypes/TileCustomMetadata"
+					},
+					"TilesetDef": {
+						"$ref": "#/otherTypes/TilesetDef"
+					},
+					"EnumDefValues": {
+						"$ref": "#/otherTypes/EnumDefValues"
+					},
+					"Tile": {
+						"$ref": "#/otherTypes/Tile"
+					},
+					"LayerDef": {
+						"$ref": "#/otherTypes/LayerDef"
+					},
+					"LevelBgPosInfos": {
+						"$ref": "#/otherTypes/LevelBgPosInfos"
+					},
+					"Level": {
+						"$ref": "#/otherTypes/Level"
+					},
+					"EnumDef": {
+						"$ref": "#/otherTypes/EnumDef"
+					},
+					"GridPoint": {
+						"$ref": "#/otherTypes/GridPoint"
+					},
+					"IntGridValueDef": {
+						"$ref": "#/otherTypes/IntGridValueDef"
+					}
+				},
+				"type": [
+					"object"
+				]
+			},
+			"defs": {
+				"description": "A structure containing all the definitions of this project",
+				"$ref": "#/otherTypes/Definitions"
+			},
+			"levels": {
+				"description": "All levels. The order of this array is only relevant in `LinearHorizontal` and `linearVertical` world layouts (see `worldLayout` value).<br/>  Otherwise, you should refer to the `worldX`,`worldY` coordinates of each Level.",
+				"items": {
+					"$ref": "#/otherTypes/Level"
+				},
+				"type": [
+					"array"
+				]
+			},
+			"jsonVersion": {
+				"description": "File format version",
+				"type": [
+					"string"
+				]
+			},
+			"externalLevels": {
+				"description": "If TRUE, one file will be saved for the project (incl. all its definitions) and one file in a sub-folder for each level.",
+				"type": [
+					"boolean"
+				]
+			}
+		},
+		"type": [
+			"object"
+		]
+	},
+	"otherTypes": {
+		"TilesetRect": {
+			"description": "This object represents a custom sub rectangle in a Tileset image.",
+			"title": "Tileset rectangle",
+			"required": [
+				"h",
+				"tilesetUid",
+				"w",
+				"x",
+				"y"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"tilesetUid": {
+					"description": "UID of the tileset",
+					"type": [
+						"integer"
+					]
+				},
+				"h": {
+					"description": "Height in pixels",
+					"type": [
+						"integer"
+					]
+				},
+				"x": {
+					"description": "X pixels coordinate of the top-left corner in the Tileset image",
+					"type": [
+						"integer"
+					]
+				},
+				"y": {
+					"description": "Y pixels coordinate of the top-left corner in the Tileset image",
+					"type": [
+						"integer"
+					]
+				},
+				"w": {
+					"description": "Width in pixels",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"FieldInstance": {
+			"title": "Field instance",
+			"required": [
+				"__identifier",
+				"__type",
+				"__value",
+				"defUid"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"__type": {
+					"description": "Type of the field, such as `Int`, `Float`, `String`, `Enum(my_enum_name)`, `Bool`, etc.<br/>  NOTE: if you enable the advanced option **Use Multilines type**, you will have \"*Multilines*\" instead of \"*String*\" when relevant.",
+					"type": [
+						"string"
+					]
+				},
+				"defUid": {
+					"description": "Reference of the **Field definition** UID",
+					"type": [
+						"integer"
+					]
+				},
+				"__identifier": {
+					"description": "Field definition identifier",
+					"type": [
+						"string"
+					]
+				},
+				"__tile": {
+					"description": "Optional TilesetRect used to display this field (this can be the field own Tile, or some other Tile guessed from the value, like an Enum).",
+					"oneOf": [
+						{
+							"type": [
+								"null"
+							]
+						},
+						{
+							"$ref": "#/otherTypes/TilesetRect"
+						}
+					]
+				},
+				"__value": {
+					"description": "Actual value of the field instance. The value type varies, depending on `__type`:<br/>   - For **classic types** (ie. Integer, Float, Boolean, String, Text and FilePath), you just get the actual value with the expected type.<br/>   - For **Color**, the value is an hexadecimal string using \"#rrggbb\" format.<br/>   - For **Enum**, the value is a String representing the selected enum value.<br/>   - For **Point**, the value is a [GridPoint](#ldtk-GridPoint) object.<br/>   - For **Tile**, the value is a [TilesetRect](#ldtk-TilesetRect) object.<br/>   - For **EntityRef**, the value is an [EntityReferenceInfos](#ldtk-EntityReferenceInfos) object.<br/><br/>  If the field is an array, then this `__value` will also be a JSON array."
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"EntityInstance": {
+			"title": "Entity instance",
+			"required": [
+				"__grid",
+				"__identifier",
+				"__pivot",
+				"__smartColor",
+				"__tags",
+				"defUid",
+				"fieldInstances",
+				"height",
+				"iid",
+				"px",
+				"width"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"iid": {
+					"description": "Unique instance identifier",
+					"type": [
+						"string"
+					]
+				},
+				"defUid": {
+					"description": "Reference of the **Entity definition** UID",
+					"type": [
+						"integer"
+					]
+				},
+				"__identifier": {
+					"description": "Entity definition identifier",
+					"type": [
+						"string"
+					]
+				},
+				"__tile": {
+					"description": "Optional TilesetRect used to display this entity (it could either be the default Entity tile, or some tile provided by a field value, like an Enum).",
+					"oneOf": [
+						{
+							"type": [
+								"null"
+							]
+						},
+						{
+							"$ref": "#/otherTypes/TilesetRect"
+						}
+					]
+				},
+				"px": {
+					"description": "Pixel coordinates (`[x,y]` format) in current level coordinate space. Don't forget optional layer offsets, if they exist!",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"__smartColor": {
+					"description": "The entity \"smart\" color, guessed from either Entity definition, or one its field instances.",
+					"type": [
+						"string"
+					]
+				},
+				"__grid": {
+					"description": "Grid-based coordinates (`[x,y]` format)",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"__pivot": {
+					"description": "Pivot coordinates  (`[x,y]` format, values are from 0 to 1) of the Entity",
+					"items": {
+						"type": [
+							"number"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"fieldInstances": {
+					"description": "An array of all custom fields and their values.",
+					"items": {
+						"$ref": "#/otherTypes/FieldInstance"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"height": {
+					"description": "Entity height in pixels. For non-resizable entities, it will be the same as Entity definition.",
+					"type": [
+						"integer"
+					]
+				},
+				"__tags": {
+					"description": "Array of tags defined in this Entity definition",
+					"items": {
+						"type": [
+							"string"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"width": {
+					"description": "Entity width in pixels. For non-resizable entities, it will be the same as Entity definition.",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"Definitions": {
+			"description": "If you're writing your own LDtk importer, you should probably just ignore *most* stuff in the `defs` section, as it contains data that are mostly important to the editor. To keep you away from the `defs` section and avoid some unnecessary JSON parsing, important data from definitions is often duplicated in fields prefixed with a double underscore (eg. `__identifier` or `__type`).  The 2 only definition types you might need here are **Tilesets** and **Enums**.",
+			"title": "Definitions",
+			"required": [
+				"entities",
+				"enums",
+				"externalEnums",
+				"layers",
+				"levelFields",
+				"tilesets"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"tilesets": {
+					"description": "All tilesets",
+					"items": {
+						"$ref": "#/otherTypes/TilesetDef"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"layers": {
+					"description": "All layer definitions",
+					"items": {
+						"$ref": "#/otherTypes/LayerDef"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"levelFields": {
+					"description": "All custom fields available to all levels.",
+					"items": {
+						"$ref": "#/otherTypes/FieldDef"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"enums": {
+					"description": "All internal enums",
+					"items": {
+						"$ref": "#/otherTypes/EnumDef"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"entities": {
+					"description": "All entities definitions, including their custom fields",
+					"items": {
+						"$ref": "#/otherTypes/EntityDef"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"externalEnums": {
+					"description": "Note: external enums are exactly the same as `enums`, except they have a `relPath` to point to an external source file.",
+					"items": {
+						"$ref": "#/otherTypes/EnumDef"
+					},
+					"type": [
+						"array"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"EnumTagValue": {
+			"description": "In a tileset definition, enum based tag infos",
+			"title": "Enum tag value",
+			"required": [
+				"enumValueId",
+				"tileIds"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"tileIds": {
+					"description": "",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"enumValueId": {
+					"description": "",
+					"type": [
+						"string"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"AutoRuleDef": {
+			"description": "This complex section isn't meant to be used by game devs at all, as these rules are completely resolved internally by the editor before any saving. You should just ignore this part.",
+			"title": "Auto-layer rule definition",
+			"required": [],
+			"additionalProperties": false,
+			"properties" : {},
+			"type": [
+				"object"
+			]
+		},
+		"FieldDef": {
+			"description": "This section is mostly only intended for the LDtk editor app itself. You can safely ignore it.",
+			"title": "Field definition",
+			"required": [],
+			"additionalProperties": false,
+			"properties" : {},
+			"type": [
+				"object"
+			]
+		},
+		"EntityDef": {
+			"title": "Entity definition",
+			"required": [
+				"color",
+				"height",
+				"identifier",
+				"nineSliceBorders",
+				"pivotX",
+				"pivotY",
+				"tileRenderMode",
+				"uid",
+				"width"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"tilesetId": {
+					"description": "Tileset ID used for optional tile display",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"pivotX": {
+					"description": "Pivot X coordinate (from 0 to 1.0)",
+					"type": [
+						"number"
+					]
+				},
+				"color": {
+					"description": "Base entity color",
+					"type": [
+						"string"
+					]
+				},
+				"tileRect": {
+					"description": "An object representing a rectangle from an existing Tileset",
+					"oneOf": [
+						{
+							"type": [
+								"null"
+							]
+						},
+						{
+							"$ref": "#/otherTypes/TilesetRect"
+						}
+					]
+				},
+				"tileRenderMode": {
+					"description": "An enum describing how the the Entity tile is rendered inside the Entity bounds. Possible values: `Cover`, `FitInside`, `Repeat`, `Stretch`, `FullSizeCropped`, `FullSizeUncropped`, `NineSlice`",
+					"enum": [
+						"Cover",
+						"FitInside",
+						"Repeat",
+						"Stretch",
+						"FullSizeCropped",
+						"FullSizeUncropped",
+						"NineSlice"
+					]
+				},
+				"nineSliceBorders": {
+					"description": "An array of 4 dimensions for the up/right/down/left borders (in this order) when using 9-slice mode for `tileRenderMode`.<br/>  If the tileRenderMode is not NineSlice, then this array is empty.<br/>  See: https://en.wikipedia.org/wiki/9-slice_scaling",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"uid": {
+					"description": "Unique Int identifier",
+					"type": [
+						"integer"
+					]
+				},
+				"height": {
+					"description": "Pixel height",
+					"type": [
+						"integer"
+					]
+				},
+				"identifier": {
+					"description": "User defined unique identifier",
+					"type": [
+						"string"
+					]
+				},
+				"pivotY": {
+					"description": "Pivot Y coordinate (from 0 to 1.0)",
+					"type": [
+						"number"
+					]
+				},
+				"width": {
+					"description": "Pixel width",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"AutoLayerRuleGroup": {
+			"title": "Auto-layer rule group",
+			"required": [
+				"active",
+				"isOptional",
+				"name",
+				"rules",
+				"uid"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"description": "",
+					"type": [
+						"string"
+					]
+				},
+				"isOptional": {
+					"description": "",
+					"type": [
+						"boolean"
+					]
+				},
+				"uid": {
+					"description": "",
+					"type": [
+						"integer"
+					]
+				},
+				"active": {
+					"description": "",
+					"type": [
+						"boolean"
+					]
+				},
+				"rules": {
+					"description": "",
+					"items": {
+						"$ref": "#/otherTypes/AutoRuleDef"
+					},
+					"type": [
+						"array"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"IntGridValueInstance": {
+			"description": "IntGrid value instance",
+			"title": "IntGrid value instance",
+			"required": [
+				"coordId",
+				"v"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"v": {
+					"description": "IntGrid value",
+					"type": [
+						"integer"
+					]
+				},
+				"coordId": {
+					"description": "Coordinate ID in the layer grid",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"NeighbourLevel": {
+			"description": "Nearby level info",
+			"title": "Neighbour level",
+			"required": [
+				"dir",
+				"levelIid"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"levelIid": {
+					"description": "Neighbour Instance Identifier",
+					"type": [
+						"string"
+					]
+				},
+				"dir": {
+					"description": "A single lowercase character tipping on the level location (`n`orth, `s`outh, `w`est, `e`ast).",
+					"type": [
+						"string"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"LayerInstance": {
+			"title": "Layer instance",
+			"required": [
+				"__cHei",
+				"__cWid",
+				"__gridSize",
+				"__identifier",
+				"__opacity",
+				"__pxTotalOffsetX",
+				"__pxTotalOffsetY",
+				"__type",
+				"autoLayerTiles",
+				"entityInstances",
+				"gridTiles",
+				"iid",
+				"intGridCsv",
+				"layerDefUid",
+				"levelId",
+				"pxOffsetX",
+				"pxOffsetY",
+				"visible"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"__cHei": {
+					"description": "Grid-based height",
+					"type": [
+						"integer"
+					]
+				},
+				"pxOffsetX": {
+					"description": "X offset in pixels to render this layer, usually 0 (IMPORTANT: this should be added to the `LayerDef` optional offset, see `__pxTotalOffsetX`)",
+					"type": [
+						"integer"
+					]
+				},
+				"__tilesetRelPath": {
+					"description": "The relative path to corresponding Tileset, if any.",
+					"type": [
+						"string",
+						"null"
+					]
+				},
+				"iid": {
+					"description": "Unique layer instance identifier",
+					"type": [
+						"string"
+					]
+				},
+				"levelId": {
+					"description": "Reference to the UID of the level containing this layer instance",
+					"type": [
+						"integer"
+					]
+				},
+				"__type": {
+					"description": "Layer type (possible values: IntGrid, Entities, Tiles or AutoLayer)",
+					"type": [
+						"string"
+					]
+				},
+				"autoLayerTiles": {
+					"description": "An array containing all tiles generated by Auto-layer rules. The array is already sorted in display order (ie. 1st tile is beneath 2nd, which is beneath 3rd etc.).<br/><br/>  Note: if multiple tiles are stacked in the same cell as the result of different rules, all tiles behind opaque ones will be discarded.",
+					"items": {
+						"$ref": "#/otherTypes/Tile"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"__identifier": {
+					"description": "Layer definition identifier",
+					"type": [
+						"string"
+					]
+				},
+				"__gridSize": {
+					"description": "Grid size",
+					"type": [
+						"integer"
+					]
+				},
+				"__pxTotalOffsetY": {
+					"description": "Total layer Y pixel offset, including both instance and definition offsets.",
+					"type": [
+						"integer"
+					]
+				},
+				"intGridCsv": {
+					"description": "A list of all values in the IntGrid layer, stored in CSV format (Comma Separated Values).<br/>  Order is from left to right, and top to bottom (ie. first row from left to right, followed by second row, etc).<br/>  `0` means \"empty cell\" and IntGrid values start at 1.<br/>  The array size is `__cWid` x `__cHei` cells.",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"overrideTilesetUid": {
+					"description": "This layer can use another tileset by overriding the tileset UID here.",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"visible": {
+					"description": "Layer instance visibility",
+					"type": [
+						"boolean"
+					]
+				},
+				"entityInstances": {
+					"description": "",
+					"items": {
+						"$ref": "#/otherTypes/EntityInstance"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"__opacity": {
+					"description": "Layer opacity as Float [0-1]",
+					"type": [
+						"number"
+					]
+				},
+				"layerDefUid": {
+					"description": "Reference the Layer definition UID",
+					"type": [
+						"integer"
+					]
+				},
+				"__pxTotalOffsetX": {
+					"description": "Total layer X pixel offset, including both instance and definition offsets.",
+					"type": [
+						"integer"
+					]
+				},
+				"__cWid": {
+					"description": "Grid-based width",
+					"type": [
+						"integer"
+					]
+				},
+				"pxOffsetY": {
+					"description": "Y offset in pixels to render this layer, usually 0 (IMPORTANT: this should be added to the `LayerDef` optional offset, see `__pxTotalOffsetY`)",
+					"type": [
+						"integer"
+					]
+				},
+				"__tilesetDefUid": {
+					"description": "The definition UID of corresponding Tileset, if any.",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"gridTiles": {
+					"description": "",
+					"items": {
+						"$ref": "#/otherTypes/Tile"
+					},
+					"type": [
+						"array"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"World": {
+			"description": "**IMPORTANT**: this type is not used *yet* in current LDtk version. It's only presented here as a preview of a planned feature.  A World contains multiple levels, and it has its own layout settings.",
+			"title": "World",
+			"required": [
+				"identifier",
+				"iid",
+				"levels",
+				"worldGridHeight",
+				"worldGridWidth",
+				"worldLayout"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"worldGridWidth": {
+					"description": "Width of the world grid in pixels.",
+					"type": [
+						"integer"
+					]
+				},
+				"iid": {
+					"description": "Unique instance identifer",
+					"type": [
+						"string"
+					]
+				},
+				"worldGridHeight": {
+					"description": "Height of the world grid in pixels.",
+					"type": [
+						"integer"
+					]
+				},
+				"worldLayout": {
+					"description": "An enum that describes how levels are organized in this project (ie. linearly or in a 2D space). Possible values: `Free`, `GridVania`, `LinearHorizontal`, `LinearVertical`, `null`, `null`",
+					"enum": [
+						"Free",
+						"GridVania",
+						"LinearHorizontal",
+						"LinearVertical",
+						null,
+						null
+					]
+				},
+				"levels": {
+					"description": "All levels from this world. The order of this array is only relevant in `LinearHorizontal` and `linearVertical` world layouts (see `worldLayout` value). Otherwise, you should refer to the `worldX`,`worldY` coordinates of each Level.",
+					"items": {
+						"$ref": "#/otherTypes/Level"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"identifier": {
+					"description": "User defined unique identifier",
+					"type": [
+						"string"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"EntityReferenceInfos": {
+			"description": "This object is used in Field Instances to describe an EntityRef value.",
+			"title": "Field instance entity reference",
+			"required": [
+				"entityIid",
+				"layerIid",
+				"levelIid",
+				"worldIid"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"worldIid": {
+					"description": "IID of the World containing the refered EntityInstance",
+					"type": [
+						"string"
+					]
+				},
+				"entityIid": {
+					"description": "IID of the refered EntityInstance",
+					"type": [
+						"string"
+					]
+				},
+				"layerIid": {
+					"description": "IID of the LayerInstance containing the refered EntityInstance",
+					"type": [
+						"string"
+					]
+				},
+				"levelIid": {
+					"description": "IID of the Level containing the refered EntityInstance",
+					"type": [
+						"string"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"TileCustomMetadata": {
+			"description": "In a tileset definition, user defined meta-data of a tile.",
+			"title": "Tile custom metadata",
+			"required": [
+				"data",
+				"tileId"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"tileId": {
+					"description": "",
+					"type": [
+						"integer"
+					]
+				},
+				"data": {
+					"description": "",
+					"type": [
+						"string"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"TilesetDef": {
+			"description": "The `Tileset` definition is the most important part among project definitions. It contains some extra informations about each integrated tileset. If you only had to parse one definition section, that would be the one.",
+			"title": "Tileset definition",
+			"required": [
+				"__cHei",
+				"__cWid",
+				"customData",
+				"enumTags",
+				"identifier",
+				"padding",
+				"pxHei",
+				"pxWid",
+				"relPath",
+				"spacing",
+				"tags",
+				"tileGridSize",
+				"uid"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"__cHei": {
+					"description": "Grid-based height",
+					"type": [
+						"integer"
+					]
+				},
+				"pxHei": {
+					"description": "Image height in pixels",
+					"type": [
+						"integer"
+					]
+				},
+				"customData": {
+					"description": "An array of custom tile metadata",
+					"items": {
+						"$ref": "#/otherTypes/TileCustomMetadata"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"tagsSourceEnumUid": {
+					"description": "Optional Enum definition UID used for this tileset meta-data",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"uid": {
+					"description": "Unique Intidentifier",
+					"type": [
+						"integer"
+					]
+				},
+				"padding": {
+					"description": "Distance in pixels from image borders",
+					"type": [
+						"integer"
+					]
+				},
+				"enumTags": {
+					"description": "Tileset tags using Enum values specified by `tagsSourceEnumId`. This array contains 1 element per Enum value, which contains an array of all Tile IDs that are tagged with it.",
+					"items": {
+						"$ref": "#/otherTypes/EnumTagValue"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"pxWid": {
+					"description": "Image width in pixels",
+					"type": [
+						"integer"
+					]
+				},
+				"__cWid": {
+					"description": "Grid-based width",
+					"type": [
+						"integer"
+					]
+				},
+				"spacing": {
+					"description": "Space in pixels between all tiles",
+					"type": [
+						"integer"
+					]
+				},
+				"identifier": {
+					"description": "User defined unique identifier",
+					"type": [
+						"string"
+					]
+				},
+				"tags": {
+					"description": "An array of user-defined tags to organize the Tilesets",
+					"items": {
+						"type": [
+							"string"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"embedAtlas": {
+					"description": "If this value is set, then it means that this atlas uses an internal LDtk atlas image instead of a loaded one. Possible values: &lt;`null`&gt;, `LdtkIcons`, `null`",
+					"enum": [
+						"LdtkIcons",
+						null,
+						null
+					]
+				},
+				"relPath": {
+					"description": "Path to the source file, relative to the current project JSON file",
+					"type": [
+						"string"
+					]
+				},
+				"tileGridSize": {
+					"description": "",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"EnumDefValues": {
+			"title": "Enum value definition",
+			"required": [
+				"color",
+				"id"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"tileId": {
+					"description": "The optional ID of the tile",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"color": {
+					"description": "Optional color",
+					"type": [
+						"integer"
+					]
+				},
+				"id": {
+					"description": "Enum value",
+					"type": [
+						"string"
+					]
+				},
+				"__tileSrcRect": {
+					"description": "An array of 4 Int values that refers to the tile in the tileset image: `[ x, y, width, height ]`",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array",
+						"null"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"Tile": {
+			"description": "This structure represents a single tile from a given Tileset.",
+			"title": "Tile instance",
+			"required": [
+				"f",
+				"px",
+				"src",
+				"t"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"t": {
+					"description": "The *Tile ID* in the corresponding tileset.",
+					"type": [
+						"integer"
+					]
+				},
+				"px": {
+					"description": "Pixel coordinates of the tile in the **layer** (`[x,y]` format). Don't forget optional layer offsets, if they exist!",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"f": {
+					"description": "\"Flip bits\", a 2-bits integer to represent the mirror transformations of the tile.<br/>   - Bit 0 = X flip<br/>   - Bit 1 = Y flip<br/>   Examples: f=0 (no flip), f=1 (X flip only), f=2 (Y flip only), f=3 (both flips)",
+					"type": [
+						"integer"
+					]
+				},
+				"src": {
+					"description": "Pixel coordinates of the tile in the **tileset** (`[x,y]` format)",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"LayerDef": {
+			"title": "Layer definition",
+			"required": [
+				"__type",
+				"displayOpacity",
+				"gridSize",
+				"identifier",
+				"intGridValues",
+				"parallaxFactorX",
+				"parallaxFactorY",
+				"parallaxScaling",
+				"pxOffsetX",
+				"pxOffsetY",
+				"uid"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"pxOffsetX": {
+					"description": "X offset of the layer, in pixels (IMPORTANT: this should be added to the `LayerInstance` optional offset)",
+					"type": [
+						"integer"
+					]
+				},
+				"displayOpacity": {
+					"description": "Opacity of the layer (0 to 1.0)",
+					"type": [
+						"number"
+					]
+				},
+				"parallaxFactorY": {
+					"description": "Parallax vertical factor (from -1 to 1, defaults to 0) which affects the scrolling speed of this layer, creating a fake 3D (parallax) effect.",
+					"type": [
+						"number"
+					]
+				},
+				"__type": {
+					"description": "Type of the layer (*IntGrid, Entities, Tiles or AutoLayer*)",
+					"type": [
+						"string"
+					]
+				},
+				"tilesetDefUid": {
+					"description": "Reference to the default Tileset UID being used by this layer definition.<br/>  **WARNING**: some layer *instances* might use a different tileset. So most of the time, you should probably use the `__tilesetDefUid` value found in layer instances.<br/>  Note: since version 1.0.0, the old `autoTilesetDefUid` was removed and merged into this value.",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"autoSourceLayerDefUid": {
+					"description": "",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"parallaxScaling": {
+					"description": "If true (default), a layer with a parallax factor will also be scaled up/down accordingly.",
+					"type": [
+						"boolean"
+					]
+				},
+				"uid": {
+					"description": "Unique Int identifier",
+					"type": [
+						"integer"
+					]
+				},
+				"intGridValues": {
+					"description": "An array that defines extra optional info for each IntGrid value.<br/>  WARNING: the array order is not related to actual IntGrid values! As user can re-order IntGrid values freely, you may value \"2\" before value \"1\" in this array.",
+					"items": {
+						"$ref": "#/otherTypes/IntGridValueDef"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"identifier": {
+					"description": "User defined unique identifier",
+					"type": [
+						"string"
+					]
+				},
+				"pxOffsetY": {
+					"description": "Y offset of the layer, in pixels (IMPORTANT: this should be added to the `LayerInstance` optional offset)",
+					"type": [
+						"integer"
+					]
+				},
+				"gridSize": {
+					"description": "Width and height of the grid in pixels",
+					"type": [
+						"integer"
+					]
+				},
+				"parallaxFactorX": {
+					"description": "Parallax horizontal factor (from -1 to 1, defaults to 0) which affects the scrolling speed of this layer, creating a fake 3D (parallax) effect.",
+					"type": [
+						"number"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"LevelBgPosInfos": {
+			"description": "Level background image position info",
+			"title": "Level background position",
+			"required": [
+				"cropRect",
+				"scale",
+				"topLeftPx"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"cropRect": {
+					"description": "An array of 4 float values describing the cropped sub-rectangle of the displayed background image. This cropping happens when original is larger than the level bounds. Array format: `[ cropX, cropY, cropWidth, cropHeight ]`",
+					"items": {
+						"type": [
+							"number"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"scale": {
+					"description": "An array containing the `[scaleX,scaleY]` values of the **cropped** background image, depending on `bgPos` option.",
+					"items": {
+						"type": [
+							"number"
+						]
+					},
+					"type": [
+						"array"
+					]
+				},
+				"topLeftPx": {
+					"description": "An array containing the `[x,y]` pixel coordinates of the top-left corner of the **cropped** background image, depending on `bgPos` option.",
+					"items": {
+						"type": [
+							"integer"
+						]
+					},
+					"type": [
+						"array"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"Level": {
+			"description": "This section contains all the level data. It can be found in 2 distinct forms, depending on Project current settings:  - If \"*Separate level files*\" is **disabled** (default): full level data is *embedded* inside the main Project JSON file, - If \"*Separate level files*\" is **enabled**: level data is stored in *separate* standalone `.ldtkl` files (one per level). In this case, the main Project JSON file will still contain most level data, except heavy sections, like the `layerInstances` array (which will be null). The `externalRelPath` string points to the `ldtkl` file.  A `ldtkl` file is just a JSON file containing exactly what is described below.",
+			"title": "Level",
+			"required": [
+				"__bgColor",
+				"__neighbours",
+				"fieldInstances",
+				"identifier",
+				"iid",
+				"pxHei",
+				"pxWid",
+				"uid",
+				"worldDepth",
+				"worldX",
+				"worldY"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"__neighbours": {
+					"description": "An array listing all other levels touching this one on the world map.<br/>  Only relevant for world layouts where level spatial positioning is manual (ie. GridVania, Free). For Horizontal and Vertical layouts, this array is always empty.",
+					"items": {
+						"$ref": "#/otherTypes/NeighbourLevel"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"__bgColor": {
+					"description": "Background color of the level (same as `bgColor`, except the default value is automatically used here if its value is `null`)",
+					"type": [
+						"string"
+					]
+				},
+				"worldX": {
+					"description": "World X coordinate in pixels.<br/>  Only relevant for world layouts where level spatial positioning is manual (ie. GridVania, Free). For Horizontal and Vertical layouts, the value is always -1 here.",
+					"type": [
+						"integer"
+					]
+				},
+				"externalRelPath": {
+					"description": "This value is not null if the project option \"*Save levels separately*\" is enabled. In this case, this **relative** path points to the level Json file.",
+					"type": [
+						"string",
+						"null"
+					]
+				},
+				"iid": {
+					"description": "Unique instance identifier",
+					"type": [
+						"string"
+					]
+				},
+				"pxHei": {
+					"description": "Height of the level in pixels",
+					"type": [
+						"integer"
+					]
+				},
+				"worldY": {
+					"description": "World Y coordinate in pixels.<br/>  Only relevant for world layouts where level spatial positioning is manual (ie. GridVania, Free). For Horizontal and Vertical layouts, the value is always -1 here.",
+					"type": [
+						"integer"
+					]
+				},
+				"__bgPos": {
+					"description": "Position informations of the background image, if there is one.",
+					"oneOf": [
+						{
+							"type": [
+								"null"
+							]
+						},
+						{
+							"$ref": "#/otherTypes/LevelBgPosInfos"
+						}
+					]
+				},
+				"uid": {
+					"description": "Unique Int identifier",
+					"type": [
+						"integer"
+					]
+				},
+				"fieldInstances": {
+					"description": "An array containing this level custom field values.",
+					"items": {
+						"$ref": "#/otherTypes/FieldInstance"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"pxWid": {
+					"description": "Width of the level in pixels",
+					"type": [
+						"integer"
+					]
+				},
+				"identifier": {
+					"description": "User defined unique identifier",
+					"type": [
+						"string"
+					]
+				},
+				"layerInstances": {
+					"description": "An array containing all Layer instances. **IMPORTANT**: if the project option \"*Save levels separately*\" is enabled, this field will be `null`.<br/>  This array is **sorted in display order**: the 1st layer is the top-most and the last is behind.",
+					"items": {
+						"$ref": "#/otherTypes/LayerInstance"
+					},
+					"type": [
+						"array",
+						"null"
+					]
+				},
+				"bgRelPath": {
+					"description": "The *optional* relative path to the level background image.",
+					"type": [
+						"string",
+						"null"
+					]
+				},
+				"worldDepth": {
+					"description": "Index that represents the \"depth\" of the level in the world. Default is 0, greater means \"above\", lower means \"below\".<br/>  This value is mostly used for display only and is intended to make stacking of levels easier to manage.",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"EnumDef": {
+			"title": "Enum definition",
+			"required": [
+				"identifier",
+				"tags",
+				"uid",
+				"values"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"externalRelPath": {
+					"description": "Relative path to the external file providing this Enum",
+					"type": [
+						"string",
+						"null"
+					]
+				},
+				"uid": {
+					"description": "Unique Int identifier",
+					"type": [
+						"integer"
+					]
+				},
+				"values": {
+					"description": "All possible enum values, with their optional Tile infos.",
+					"items": {
+						"$ref": "#/otherTypes/EnumDefValues"
+					},
+					"type": [
+						"array"
+					]
+				},
+				"iconTilesetUid": {
+					"description": "Tileset UID if provided",
+					"type": [
+						"integer",
+						"null"
+					]
+				},
+				"identifier": {
+					"description": "User defined unique identifier",
+					"type": [
+						"string"
+					]
+				},
+				"tags": {
+					"description": "An array of user-defined tags to organize the Enums",
+					"items": {
+						"type": [
+							"string"
+						]
+					},
+					"type": [
+						"array"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"GridPoint": {
+			"description": "This object is just a grid-based coordinate used in Field values.",
+			"title": "Field instance grid point",
+			"required": [
+				"cx",
+				"cy"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"cy": {
+					"description": "Y grid-based coordinate",
+					"type": [
+						"integer"
+					]
+				},
+				"cx": {
+					"description": "X grid-based coordinate",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		},
+		"IntGridValueDef": {
+			"description": "IntGrid value definition",
+			"title": "IntGrid value definition",
+			"required": [
+				"color",
+				"value"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"color": {
+					"description": "",
+					"type": [
+						"string"
+					]
+				},
+				"identifier": {
+					"description": "User defined unique identifier",
+					"type": [
+						"string",
+						"null"
+					]
+				},
+				"value": {
+					"description": "The IntGrid value itself",
+					"type": [
+						"integer"
+					]
+				}
+			},
+			"type": [
+				"object"
+			]
+		}
+	}
+}

--- a/src/docGenerator/DocGenerator.hx
+++ b/src/docGenerator/DocGenerator.hx
@@ -81,7 +81,7 @@ class DocGenerator {
 	/**
 		Generate Markdown doc and Json schema
 	**/
-	public static function run(className:String, xmlPath:String, ?mdPath:String, ?jsonPath:String, deleteXml=false) {
+	public static function run(className:String, xmlPath:String, ?mdPath:String, ?jsonPath:String, ?minimalJsonPath:String, deleteXml=false) {
 		allGlobalTypes = [];
 		allEnums = [];
 
@@ -166,7 +166,11 @@ class DocGenerator {
 
 		// Json schema output
 		Sys.println("Generating JSON schema...");
-		genJsonSchema(xml, className, xmlPath, jsonPath);
+		genJsonSchema(xml, className, xmlPath, jsonPath, false);
+
+		// Minimal Json schema output
+		Sys.println("Generating Minimal JSON schema...");
+		genJsonSchema(xml, className, xmlPath, minimalJsonPath, true);
 
 		// Dump version to version.txt
 		Sys.println("Dumping version file...");
@@ -333,7 +337,7 @@ class DocGenerator {
 	/**
 		Build Json schema
 	**/
-	static function genJsonSchema(xml:haxe.xml.Access, className:String, xmlPath:String, ?jsonPath:String) {
+	static function genJsonSchema(xml:haxe.xml.Access, className:String, xmlPath:String, ?jsonPath:String, isMinimal:Bool) {
 		// Prepare Json structure
 		var json = {
 			LdtkJsonRoot: null,
@@ -361,6 +365,9 @@ class DocGenerator {
 
 			// List fields
 			for(f in getFieldsInfos(type.xml.node.a)) {
+				if( (f.removed != null || f.isInternal || type.onlyInternalFields || f.deprecation != null) && isMinimal )
+					continue;
+
 				var subType = getSchemaType(f.type);
 				subType.description = f.descMd.join('\n');
 


### PR DESCRIPTION
Generate another scheme with all internal, removed and deprecated fields removed this will produce much cleaner quicktype files that are friendlier to work with.