### PR TITLE
Change LUA to Lua

### DIFF
--- a/src/electron.renderer/Lang.hx
+++ b/src/electron.renderer/Lang.hx
@@ -109,7 +109,7 @@ class Lang {
 			case LangC: t._("C/C++/C#");
 			case LangHaxe: t._("Haxe");
 			case LangJS: t._("Javascript");
-			case LangLua: t._("LUA");
+			case LangLua: t._("Lua");
 		}
 	}
 


### PR DESCRIPTION
See https://www.lua.org/about.html

Like most names, it should be written in lower case with an initial capital, that is, "Lua". Please do not write it as "LUA", which is both ugly and confusing, because then it becomes an acronym with different meanings for different people. So, please, write "Lua" right!