### PR TITLE
Tileset enum overlay

### DIFF
--- a/app/assets/tpl/pages/editor.html
+++ b/app/assets/tpl/pages/editor.html
@@ -57,6 +57,10 @@
 		<div class="icon tile"></div>
 	</li>
 
+	<li class="tileEnums" title="**Tile enums** Only applies to Tiles layers. If this option is enabled, you will see enum colours over your tiles." keys="Shift+E" tip="right">
+		<div class="icon enum on"></div>
+		<div class="icon enum off"></div>
+	</li>
 </ul>
 
 <div id="worldDepths">

--- a/app/assets/tpl/pages/editor.html
+++ b/app/assets/tpl/pages/editor.html
@@ -42,6 +42,11 @@
 		<div class="icon showDetailsOff off"></div>
 	</li>
 
+	<li class="tileEnums" title="**Show/hide enums** Only applies to Tiles layers. If this option is enabled, you will see enum colours over your tiles." tip="right">
+		<div class="icon enum on"></div>
+		<div class="icon enum off"></div>
+	</li>
+
 	<li class="separator"></li>
 
 	<li class="singleLayerMode" title="**Single layer mode** Enable this to fade all other layers, and focus on active layer only. NOTE: this will also affect the Selection tool (ALT+click)." keys="A" tip="right">
@@ -55,11 +60,6 @@
 
 	<li class="tileStacking" title="**Tile stacking** Only applies to Tiles layers. If this option is enabled, you will be able to stack multiple tiles in a single grid cell." keys="Shift+T" tip="right">
 		<div class="icon tile"></div>
-	</li>
-
-	<li class="tileEnums" title="**Tile enums** Only applies to Tiles layers. If this option is enabled, you will see enum colours over your tiles." keys="Shift+E" tip="right">
-		<div class="icon enum on"></div>
-		<div class="icon enum off"></div>
 	</li>
 </ul>
 

--- a/src/electron.common/Settings.hx
+++ b/src/electron.common/Settings.hx
@@ -8,6 +8,7 @@ typedef AppSettings = {
 	var singleLayerMode : Bool;
 	var emptySpaceSelection : Bool;
 	var tileStacking : Bool;
+	var tileEnumOverlays : Bool;
 	var showDetails : Bool;
 	var useBestGPU : Bool;
 	var startFullScreen: Bool;
@@ -60,6 +61,7 @@ class Settings {
 			singleLayerMode: false,
 			emptySpaceSelection: true,
 			tileStacking: true,
+			tileEnumOverlays : false,
 			showDetails: true,
 			useBestGPU: true,
 			startFullScreen: false,

--- a/src/electron.renderer/EditorTypes.hx
+++ b/src/electron.renderer/EditorTypes.hx
@@ -57,6 +57,7 @@ enum GlobalEvent {
 	TilesetSelectionSaved(td:data.def.TilesetDef);
 	TilesetDefPixelDataCacheRebuilt(td:data.def.TilesetDef);
 	TilesetDefSorted;
+	TilesetEnumChanged;
 
 	EntityInstanceAdded(ei:data.inst.EntityInstance);
 	EntityInstanceRemoved(ei:data.inst.EntityInstance);

--- a/src/electron.renderer/display/LayerRender.hx
+++ b/src/electron.renderer/display/LayerRender.hx
@@ -85,6 +85,8 @@ class LayerRender {
 			mask.height = li.pxHei;
 		}
 
+		var showEnums = App.ME.settings.v.tileEnumOverlays;
+
 		var renderTarget = mask!=null ? mask : root;
 
 		switch li.def.type {
@@ -148,9 +150,19 @@ class LayerRender {
 
 		case Tiles:
 			// Classic tiles layer
+			var offX = 2;
+			var offY = 2;
 			var td = li.getTilesetDef();
 			if( td!=null && td.isAtlasLoaded() ) {
+				var ed = td.getTagsEnumDef();
 				var tg = new h2d.TileGroup( td.getAtlasTile(), renderTarget );
+				var gr = new h2d.Graphics(renderTarget);
+
+				// If we're showing enums, dim the tileset slightly so the overlays 
+				// stand out.
+				if (showEnums) {
+					tg.setDefaultColor(0xcccccc, .5);
+				}
 
 				for(cy in 0...li.cHei)
 				for(cx in 0...li.cWid) {
@@ -163,14 +175,25 @@ class LayerRender {
 						t.setCenterRatio(li.def.tilePivotX, li.def.tilePivotY);
 						var sx = M.hasBit(tileInf.flips, 0) ? -1 : 1;
 						var sy = M.hasBit(tileInf.flips, 1) ? -1 : 1;
-						tg.addTransform(
-							(cx + li.def.tilePivotX + (sx<0?1:0)) * li.def.gridSize + li.pxTotalOffsetX,
-							(cy + li.def.tilePivotX + (sy<0?1:0)) * li.def.gridSize + li.pxTotalOffsetY,
-							sx,
-							sy,
-							0,
-							t
-						);
+						var tx = (cx + li.def.tilePivotX + (sx<0?1:0)) * li.def.gridSize + li.pxTotalOffsetX;
+						var ty = (cy + li.def.tilePivotX + (sy<0?1:0)) * li.def.gridSize + li.pxTotalOffsetY;
+						tg.addTransform(tx, ty, sx, sy, 0, t);
+
+						if (showEnums) {
+							var n = 0;
+							for( ev in ed.values) {
+								if( td.hasTag(ev.id, tileInf.tileId)) {
+									gr.lineStyle(1, ev.color, 1);
+									gr.drawRect(
+										tx + n + .5,
+										ty + n + .5,
+										li.def.gridSize - 1 - n * 2,
+										li.def.gridSize - 1 - n * 2
+									);
+									n++;
+								}
+							}
+						}
 					}
 				}
 			}

--- a/src/electron.renderer/display/LayerRender.hx
+++ b/src/electron.renderer/display/LayerRender.hx
@@ -179,7 +179,7 @@ class LayerRender {
 						var ty = (cy + li.def.tilePivotX + (sy<0?1:0)) * li.def.gridSize + li.pxTotalOffsetY;
 						tg.addTransform(tx, ty, sx, sy, 0, t);
 
-						if (showEnums) {
+						if (showEnums && ed != null) {
 							var n = 0;
 							for( ev in ed.values) {
 								if( td.hasTag(ev.id, tileInf.tileId)) {

--- a/src/electron.renderer/display/LevelRender.hx
+++ b/src/electron.renderer/display/LevelRender.hx
@@ -260,8 +260,8 @@ class LevelRender extends dn.Process {
 						invalidateLayer(li);
 
 			case EnumDefRemoved, EnumDefChanged, EnumDefValueRemoved:
-				for(li in editor.curLevel.layerInstances)
-					if( li.def.type==Entities )
+				for( li in editor.curLevel.layerInstances)
+					if( settings.v.tileEnumOverlays || li.def.type==Entities )
 						invalidateLayer(li);
 
 			case LevelFieldInstanceChanged(l,fi):

--- a/src/electron.renderer/display/LevelRender.hx
+++ b/src/electron.renderer/display/LevelRender.hx
@@ -244,6 +244,10 @@ class LevelRender extends dn.Process {
 
 			case TilesetDefSorted:
 
+			case TilesetEnumChanged:
+				if (settings.v.tileEnumOverlays)
+					invalidateAll();
+
 			case EntityDefRemoved, EntityDefChanged, EntityDefSorted:
 				for(li in editor.curLevel.layerInstances)
 					if( li.def.type==Entities )

--- a/src/electron.renderer/display/LevelRender.hx
+++ b/src/electron.renderer/display/LevelRender.hx
@@ -246,7 +246,8 @@ class LevelRender extends dn.Process {
 
 			case TilesetEnumChanged:
 				if (settings.v.tileEnumOverlays)
-					invalidateAll();
+					for( li in editor.curLevel.layerInstances)
+						invalidateLayer(li);
 
 			case EntityDefRemoved, EntityDefChanged, EntityDefSorted:
 				for(li in editor.curLevel.layerInstances)

--- a/src/electron.renderer/page/Editor.hx
+++ b/src/electron.renderer/page/Editor.hx
@@ -1309,7 +1309,12 @@ class Editor extends Page {
 			(v)->setTileStacking(v),
 			()->curLayerDef!=null && curLayerDef.type==Tiles
 		);
-
+		applyEditOption(
+			jEditOptions.find("li.tileEnums"),
+			()->settings.v.tileEnumOverlays,
+			(v)->setTileEnumOverlays(v),
+			()->curLayerDef!=null && curLayerDef.type==Tiles
+		);
 		JsTools.parseComponents(jEditOptions);
 	}
 
@@ -1397,6 +1402,15 @@ class Editor extends Page {
 		App.ME.settings.save();
 		selectionTool.clear();
 		N.quick( "Tile stacking: "+L.onOff( settings.v.tileStacking ));
+		updateEditOptions();
+	}
+
+	public function setTileEnumOverlays(v:Bool) {
+		settings.v.tileEnumOverlays = v;
+		App.ME.settings.save();
+		levelRender.invalidateAll();
+		selectionTool.clear();
+		N.quick( "Tile enum overlay: "+L.onOff( settings.v.tileEnumOverlays ));
 		updateEditOptions();
 	}
 

--- a/src/electron.renderer/page/Editor.hx
+++ b/src/electron.renderer/page/Editor.hx
@@ -1752,6 +1752,7 @@ class Editor extends Page {
 			case TilesetSelectionSaved(td):
 			case TilesetDefPixelDataCacheRebuilt(td):
 			case TilesetDefSorted:
+			case TilesetEnumChanged:
 			case EntityInstanceAdded(ei): invalidateLevelCache(ei._li.level);
 			case EntityInstanceRemoved(ei): invalidateLevelCache(ei._li.level);
 			case EntityInstanceChanged(ei): invalidateLevelCache(ei._li.level);
@@ -1981,6 +1982,8 @@ class Editor extends Page {
 				project.tidy();
 
 			case TilesetDefAdded(td):
+
+			case TilesetEnumChanged:
 
 			case ProjectSettingsChanged:
 				updateBanners();

--- a/src/electron.renderer/ui/ts/TileTagger.hx
+++ b/src/electron.renderer/ui/ts/TileTagger.hx
@@ -226,6 +226,7 @@ class TileTagger extends ui.Tileset {
 			// Set/unset enum tags
 			for(tid in tileIds)
 				tilesetDef.setTag(tid, curEnumValue, added);
+			Editor.ME.ge.emit( TilesetEnumChanged );
 			refresh();
 		}
 		else {


### PR DESCRIPTION
This change adds an overlay to tileset layers to show which tiles have which enum values assigned to them. It's triggered by clicking a new "Tile enums" option in the tool palette. Tiles with an enum value are outlined in the relevant colour, as defined in the tileset editor. Tiles with multiple enum values are indicated by nested outlines. 

I made this change because I was finding it difficult to determine if tiles had enum set correctly. See #698. Also, this is my first encounter with a Haxe project so I could have taken the wrong approach with this, and there could be unforeseen issues that I've not though of.

Summary of changes:

* Adds a new "Tile enums" item to the editing options
* Adds a new `tileEnumOverlays` boolean setting
* Adds `TilesetEnumChanged` event, triggered when an enum value is assigned, changed or removed from a tile.
* Adds a `h2d.Graphics` instance to the `LayerRenderer`, which is used to draw the overlay rectangles

<img width="1554" alt="Screenshot 2022-06-18 at 13 37 10" src="https://user-images.githubusercontent.com/588665/174438003-ad3831d9-6205-4c17-9d6b-3fbb2057be15.png">