### PR TITLE
Fix build failure stemming from #738

### DIFF
--- a/app/assets/css/app.scss
+++ b/app/assets/css/app.scss
@@ -5889,6 +5889,14 @@ canvas#webgl {
 					color: $orange;
 				}
 			}
+
+			&.flips {
+				align-items: center;
+				input {
+					padding: 3px;
+					font-size: 0.8em;
+				}
+			}
 		}
 	}
 }

--- a/app/assets/tpl/entityInstanceEditor.html
+++ b/app/assets/tpl/entityInstanceEditor.html
@@ -30,6 +30,14 @@
 				<span class="unit" title="Change coordinates unit"></span>
 			</dd>
 
+			<dt>
+				Flips
+				<info>How this Entity instance is oriented on the X and Y axes.</info>
+			</dt>
+			<dd class="flips">
+				<input type="checkbox" name="x"/> X <input type="checkbox" name="y"/> Y
+			</dd>
+
 			<dt class="refs">
 				References to this entity
 				<info>This is a list of all other Entities having a Reference field pointing to this Entity.</info>

--- a/src/electron.renderer/data/inst/EntityInstance.hx
+++ b/src/electron.renderer/data/inst/EntityInstance.hx
@@ -15,6 +15,7 @@ class EntityInstance {
 	public var worldY(get,never) : Int;
 	public var customWidth : Null<Int>;
 	public var customHeight: Null<Int>;
+	public var flips : Int;
 
 	public var width(get,never) : Int;
 		inline function get_width() return customWidth!=null ? customWidth : def.width;
@@ -30,11 +31,12 @@ class EntityInstance {
 	public var bottom(get,never) : Int; inline function get_bottom() return top + height;
 
 
-	public function new(p:Project, li:LayerInstance, entityDefUid:Int, iid:String) {
+	public function new(p:Project, li:LayerInstance, entityDefUid:Int, iid:String, flips:Int = 0) {
 		_project = p;
 		_li = li;
 		defUid = entityDefUid;
 		this.iid = iid;
+		this.flips = flips;
 	}
 
 	@:keep public function toString() {
@@ -68,6 +70,7 @@ class EntityInstance {
 			height: height,
 			defUid: defUid,
 			px: [x,y],
+			f: flips,
 			fieldInstances: {
 				var all = [];
 				for(fd in def.fieldDefs)
@@ -88,6 +91,7 @@ class EntityInstance {
 			layer: _li.def.identifier,
 			x : x,
 			y : y,
+			f: flips,
 			width: width,
 			height: height,
 			color: getSmartColor(false),
@@ -108,6 +112,8 @@ class EntityInstance {
 		var ei = new EntityInstance(project, li, JsonTools.readInt(json.defUid), json.iid);
 		ei.x = JsonTools.readInt( json.px[0], 0 );
 		ei.y = JsonTools.readInt( json.px[1], 0 );
+
+		ei.flips = JsonTools.readInt( json.f, 0 );
 
 		ei.customWidth = JsonTools.readNullableInt( json.width );
 		if( ei.customWidth==ei.def.width )

--- a/src/electron.renderer/ui/EntityInstanceEditor.hx
+++ b/src/electron.renderer/ui/EntityInstanceEditor.hx
@@ -262,6 +262,57 @@ class EntityInstanceEditor extends dn.Process {
 		if( UNIT_GRID )
 			i.setUnit(ei._li.def.gridSize);
 
+		// Flip block
+		var jFlips = jPropsForm.find(".flips");
+		var jUnit2 = jFlips.find(".unit");
+		jUnit2.text( UNIT_GRID ? "cells" : "px" );
+		jUnit2.click( _->{
+			UNIT_GRID = !UNIT_GRID;
+			updateInstancePropsForm();
+		});
+
+		// X
+		var i = new form.input.BoolInput(
+			jFlips.find("[name=x]"),
+			()->(ei.flips == 1 || ei.flips == 3),
+			(v)->{
+				switch (ei.flips) {
+					case 0:
+						ei.flips = 1;
+					case 1:
+						ei.flips = 0;
+					case 2:
+						ei.flips = 3;
+					case 3:
+						ei.flips = 2;
+				}
+			}
+		);
+		i.setEnabled( ei.def.resizableX );
+		i.linkEvent( EntityInstanceChanged(ei) );
+		i.onChange = ()->onEntityFieldChanged();
+
+		// Y
+		var i = new form.input.BoolInput(
+			jFlips.find("[name=y]"),
+			()->(ei.flips == 2 || ei.flips == 3),
+			(v)->{
+				switch (ei.flips) {
+					case 0:
+						ei.flips = 2;
+					case 2:
+						ei.flips = 0;
+					case 1:
+						ei.flips = 3;
+					case 3:
+						ei.flips = 1;
+				}
+			}
+		);
+		i.setEnabled( ei.def.resizableY );
+		i.linkEvent( EntityInstanceChanged(ei) );
+		i.onChange = ()->onEntityFieldChanged();
+
 
 		// References to this
 		var refs = project.getEntityInstancesReferingTo(ei);

--- a/src/electron.renderer/ui/modal/panel/EditAllAutoLayerRules.hx
+++ b/src/electron.renderer/ui/modal/panel/EditAllAutoLayerRules.hx
@@ -209,8 +209,8 @@ class EditAllAutoLayerRules extends ui.modal.Panel {
 				var cx = ( coordId % li.cWid );
 				var cy = Std.int( coordId / li.cWid );
 				editor.levelRender.temp.drawRect(
-					cx*li.def.gridSize + li.totalOffsetX,
-					cy*li.def.gridSize + li.totalOffsetY,
+					cx*li.def.gridSize + li.pxTotalOffsetX,
+					cy*li.def.gridSize + li.pxTotalOffsetY,
 					li.def.gridSize,
 					li.def.gridSize
 				);


### PR DESCRIPTION
PR #738 uses incorrect field names for layer offsets, causing build failures. This PR adjusts the two lines changed in #738 to resolve this, while still fixing the issue the original PR presented.