### PR TITLE
Fix build failure stemming from #738

### DIFF
--- a/src/electron.renderer/ui/modal/panel/EditAllAutoLayerRules.hx
+++ b/src/electron.renderer/ui/modal/panel/EditAllAutoLayerRules.hx
@@ -209,8 +209,8 @@ class EditAllAutoLayerRules extends ui.modal.Panel {
 				var cx = ( coordId % li.cWid );
 				var cy = Std.int( coordId / li.cWid );
 				editor.levelRender.temp.drawRect(
-					cx*li.def.gridSize + li.totalOffsetX,
-					cy*li.def.gridSize + li.totalOffsetY,
+					cx*li.def.gridSize + li.pxTotalOffsetX,
+					cy*li.def.gridSize + li.pxTotalOffsetY,
 					li.def.gridSize,
 					li.def.gridSize
 				);


### PR DESCRIPTION
For real this time, without unintended commits. Renames faulty variable references while still providing the intended fix.

