### PR TITLE
Update electron-builder to fix MacOS build issue

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,6 @@
 	},
 	"devDependencies": {
 		"electron": "^16.0.8",
-		"electron-builder": "^22.14.13"
+		"electron-builder": "^23.6.0"
 	}
 }


### PR DESCRIPTION
Fixes #783 

See https://github.com/electron-userland/electron-builder/issues/6606

This negates the need for Python 2 in the MacOS build which appears to now be missing in the MacOS Github runners.

See my fork for successful builds:

[Package MacOS](https://github.com/stephenmuss/ldtk/actions/runs/3828888292)
[package-ubuntu](https://github.com/stephenmuss/ldtk/actions/runs/3828888289)
[test-windows](https://github.com/stephenmuss/ldtk/actions/runs/3828888283)