### PR TITLE
Build universal binary for macOS supporting both Intel and Apple Silicon

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
 		"pack-prepare": "npm run doc  &&  npm run compile",
 		"pack-test": "npm run pack-prepare  &&  electron-builder build --win --dir --publish never",
 		"pack-win": "npm run pack-prepare  &&  electron-builder build --win --x64 --ia32",
-		"pack-macos": "npm run pack-prepare  &&  electron-builder build --mac --publish never",
+		"pack-macos": "npm run pack-prepare  &&  electron-builder build --mac --universal --publish never",
 		"pack-linux-x86": "npm run pack-prepare  &&  electron-builder build --linux --publish never",
 		"pack-linux-arm64": "npm run pack-prepare  &&  electron-builder build --linux --arm64 --publish never",
 		"publish-github": "npm run pack-win -- --publish always",


### PR DESCRIPTION
Currently, the macOS build is Intel-only, which runs less than optimal on Apple Silicon due to it running through the [Rosetta 2 translation layer](https://support.apple.com/en-us/HT211861).

This PR adds the `--universal` flag which instructs `electron-builder` to generate a binary that contains code for both macOS architectures.

Worth noting that this technique does increase the size of the macOS app by approximately 80% (from ~215MB to ~390MB), but keeps the package script simple, not having to set up separate build steps for each etc.