### PR TITLE
Streamlined build steps

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -12,56 +12,31 @@ on:
 
 jobs:
   build:
-
     strategy:
       matrix:
         os: [windows-latest]
-        haxe: [4.2.4]
+        haxe: [4.2.5]
       fail-fast: true
     runs-on: windows-latest
 
     steps:
-      # Get branch name
-      - name: getBranch
-        shell: bash
-        run: echo "::set-output name=v::${GITHUB_REF#refs/heads/}"
-        id: branch
-
-      # Checkout & install haxe
+      # Checkout & install haxe + node
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14"
       - uses: actions/checkout@v2
       - uses: krdlab/setup-haxe@v1
         with:
           haxe-version: ${{ matrix.haxe }}
+
+      - name: Compile CSS from SCSS files
+        uses: gha-utilities/sass-build@v0.4.11
+        with:
+          source: app/assets/css/app.scss
+          destination: app/assets/css/app.min.css
+
       - run: haxe -version
 
-      # Install libs
-      - run: haxelib install uuid
-      - run: haxelib git castle https://github.com/ncannasse/castle
-      - run: haxelib git heaps https://github.com/deepnight/heaps.git
-      - run: haxelib git hxnodejs https://github.com/HaxeFoundation/hxnodejs.git
-      - run: haxelib git electron https://github.com/tong/hxelectron.git
-      - run: haxelib git heaps-aseprite https://github.com/AustinEast/heaps-aseprite.git
-
-      # Install haxe API from same branch (if it exists)...
-      - name: Install Haxe API from same branch
-        id: installApiBranch
-        run: haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git ${{ steps.branch.outputs.v }} --always
-        continue-on-error: true
-      # ... or from master otherwise
-      - name: Install Haxe API from master
-        if: steps.installApiBranch.outcome == 'failure'
-        run: |
-          haxelib remove ldtk-haxe-api
-          haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git --always
-
-      # Install deepnightLibs
-      - run: haxelib git deepnightLibs https://github.com/deepnight/deepnightLibs.git --always
+      - run: haxe setup.hxml
       - run: haxelib list
-
-      # Node/NPM commands
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14'
-      - run: cd app && npm install
       - run: cd app && npm run compile
-

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
 				"type": "pwa-chrome",
 				"runtimeExecutable": "${workspaceFolder}/app/node_modules/electron/dist/electron.exe"
 			},
-			"runtimeArgs" : [
+			"runtimeArgs": [
 				".",
 				"--remote-debugging-port=9222"
 			],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,7 @@
 			"label": "Electron Renderer release",
 			"type": "hxml",
 			"file": "renderer.hxml",
+			"dependsOn": "Electron Main release",
 			"problemMatcher": [
 				"$haxe-absolute",
 				"$haxe",
@@ -19,11 +20,11 @@
 			},
 			"group": "build"
 		},
-
 		{
 			"label": "Electron Renderer debug",
 			"type": "hxml",
 			"file": "renderer.debug.hxml",
+			"dependsOn": "Electron Main debug",
 			"problemMatcher": [
 				"$haxe-absolute",
 				"$haxe",
@@ -38,7 +39,6 @@
 			},
 			"group": "build"
 		},
-
 		{
 			"label": "Electron Main release",
 			"type": "hxml",
@@ -57,7 +57,6 @@
 			},
 			"group": "build"
 		},
-
 		{
 			"label": "Electron Main debug",
 			"type": "hxml",
@@ -76,7 +75,6 @@
 			},
 			"group": "build"
 		},
-
 		{
 			"type": "haxe",
 			"args": "active configuration",

--- a/README.md
+++ b/README.md
@@ -19,56 +19,47 @@ Visit [LDtk.io](https://ldtk.io) to get latest version.
 
 ## Requirements
 
- - **[Haxe compiler](https://haxe.org)**: you need an up-to-date and working Haxe install  to build LDtk.
- - **[NPM](https://nodejs.org/en/download/)**: this package manager is used for various install and packaging scripts. It is packaged with NodeJS.
-
-## Installing required stuff
-
- - Open a command line **in the `ldtk` root dir**,
- - Install required Haxe libs:
- ```
- haxe setup.hxml
- ```
- - Install Electron locally and other dependencies through NPM (**IMPORTANT**: you need to be in the `app` dir):
- ```
- cd app
- npm i
- ```
-
-## Compiling *master* branch
-
-First, from the root of the repo, build the electron **Main**:
-
-```
-haxe main.debug.hxml
-```
-
-This should create a `app/assets/main.js` file.
-
-Then, build the electron **Renderer**:
-
-```
-haxe renderer.debug.hxml
-```
-
-This should create `app/assets/js/renderer.js`.
+- **[Haxe compiler](https://haxe.org)**: you need an up-to-date and working Haxe install  to build LDtk.
+- **[NPM](https://nodejs.org/en/download/)**: this package manager is used for various install and packaging scripts. It is packaged with NodeJS.
 
 ## Compiling another branch
 
-If you want to try a future version of LDtk, you can checkout branches named `dev-x.y.z` where x.y.z is version number.
+If you want to try a future version of LDtk, you can checkout branches named `dev-x.y.z` where x.y.z is version number e.g. `dev-1.2.3`
 
 **IMPORTANT**:
- - these *dev* branches might be unstables, or even broken. Therefore, it's not recommended to use, unless you plan to add or fix something on LDtk.
- - because *dev* branches might change quickly, you will need to update haxelibs often.
- - you will need to switch the *LDtk haxe API* to the **same** branch as LDtk repo. (adapt the branch name below accordingly):
+- these *dev* branches might be unstables, or even broken. Therefore, it's not recommended to use, unless you plan to add or fix something on LDtk.
+- because *dev* branches might change quickly, you will need to update haxelibs often.
+- you will need to switch the *LDtk haxe API* to the **same**/**nearest** branch as LDtk repo. (adapt the branch name below accordingly):
 
+edit this line in setup.hxml
 ```
-haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git dev-0.6.0
+--cmd haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git dev-1.2.1 --always
 ```
+
+- Run this in a terminal in the root folder of the repo
+```
+haxe setup.hxml
+```
+
+In vscode to get intilisense make sure to change the haxe configuration to `renderer.debug.hxml`
+
+If you make changes to scss remember to use a compiler such as sass or a vscode extension to compile it to css
 
 ## Running
 
-From a command line in the `app` folder, run:
+### VScode
+
+Hit `F5` then in vscode and it will compile and run everything in debug mode to start testing
+
+### Cli
+
+in the `ldtk` root folder, run:
+```
+haxe main.debug.hxml
+haxe renderer.debug.hxml
+```
+
+in the `app` folder, run:
 
 ```
 npm run start
@@ -81,12 +72,12 @@ https://github.com/deepnight/ldtk/wiki#pull-request-guidelines
 
 # Related tools & licences
 
- - Tileset images: see [README](app/extraFiles/samples/README.md) in samples
- - Haxe: https://haxe.org/
- - Heaps.io: https://heaps.io/
- - Electron: https://www.electronjs.org/
- - JQuery: https://jquery.com
- - MarkedJS: https://github.com/markedjs/marked
- - SVG icons from https://material.io
- - Default palette: "*Endesga32*" by Endesga (https://lospec.com/palette-list/endesga-32)
- - Default color blind palette: "*Colorblind 16*" by FilipWorks (https://github.com/filipworksdev/colorblind-palette-16)
+- Tileset images: see [README](app/extraFiles/samples/README.md) in samples
+- Haxe: https://haxe.org/
+- Heaps.io: https://heaps.io/
+- Electron: https://www.electronjs.org/
+- JQuery: https://jquery.com
+- MarkedJS: https://github.com/markedjs/marked
+- SVG icons from https://material.io
+- Default palette: "*Endesga32*" by Endesga (https://lospec.com/palette-list/endesga-32)
+- Default color blind palette: "*Colorblind 16*" by FilipWorks (https://github.com/filipworksdev/colorblind-palette-16)

--- a/setup.hxml
+++ b/setup.hxml
@@ -13,16 +13,21 @@
 --cmd haxelib git heaps https://github.com/deepnight/heaps.git --always
 
 --next
---cmd haxelib git hxnodejs https://github.com/HaxeFoundation/hxnodejs.git --always
+--cmd haxelib git electron https://github.com/tong/hxelectron.git --always
 
 --next
---cmd haxelib git electron https://github.com/tong/hxelectron.git --always
+--cmd haxelib git hxnodejs https://github.com/HaxeFoundation/hxnodejs.git --always
 
 --next
 --cmd haxelib git heaps-aseprite https://github.com/AustinEast/heaps-aseprite.git --always
 
 --next
+--cmd haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git --always
+
+--next
 --cmd haxelib git deepnightLibs https://github.com/deepnight/deepnightLibs.git --always
 
 --next
---cmd haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git --always
+--cmd cd app
+--cmd npm install
+--cmd cd ..


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14964651/211229783-332405c8-1d04-4c51-9833-d768ec3aa5e1.png)

Every time i go to build ldtk it takes me a while to remember the steps to get it compiling
like you are using the master branch of the node deps but electron was reverting it.
Plus i also simplified the steps to read.

WIP as im updating the actions