### PR TITLE
Fix assistant resizing as you pan

### DIFF
--- a/app/assets/css/app.scss
+++ b/app/assets/css/app.scss
@@ -9057,10 +9057,8 @@ $patternSize : 32px;
 	.wrapper .content {
 		.layout {
 			display: grid;
-			min-width: 600px;
-			max-width: 90vw;
-			min-height: 570px;
-			max-height: 72vh;
+			width: 90vw;
+			height: 72vh;
 			grid-template-columns: min-content auto;
 			grid-template-rows: 100%;
 			column-gap: 8px;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Fixed opacity inputs (icon, border and fill) in Entity panel.
  - Fixed incorrect main value when editing an existing group using Rules Assistant
  - Fixed an error with Haxe API when a tileset is not defined in layer definition.
+ - Fixed the auto-layer assitant resize as you pan.
 
 # 1.2.3
 


### PR DESCRIPTION
Fixed the Assitant resizing as you pan around and zoom.
I think the assistant being mostly fullscreen all the time makes sense makes it easier to select the tiles.

![image](https://user-images.githubusercontent.com/14964651/211376146-5880a8aa-4261-4fa4-a05b-a28e7d6dc5aa.png)
