### PR TITLE
Fix crashing when pressing Shift+W in rule editor

### DIFF
--- a/src/electron.renderer/ui/Modal.hx
+++ b/src/electron.renderer/ui/Modal.hx
@@ -127,9 +127,11 @@ class Modal extends dn.Process {
 
 	public static function closeAll(?except:Modal) {
 		var any = false;
-		for(w in ALL)
-			if( !w.isClosing() && ( except==null || w!=except ) && w.canBeClosedManually ) {
-				w.close();
+
+		var w = ALL.length;
+		while (--w >= 0)
+			if ( !ALL[w].isClosing() && ( except==null || ALL[w]!=except ) && ALL[w].canBeClosedManually ) {
+				ALL[w].close();
 				any = true;
 			}
 		return any;


### PR DESCRIPTION
Closes #826. 

This PR basically changes the way `closeAll()` in `Modal.hx` works. Instead of looping through all the open modals and closing them, it does the same thing but instead it loops through `ALL` in reverse.