### PR TITLE
Pivot-based entity flips

### DIFF
--- a/app/assets/tpl/editEntityDefs.html
+++ b/app/assets/tpl/editEntityDefs.html
@@ -89,6 +89,23 @@
 					Keep aspect ratio
 				</label>
 			</dd>
+			<dd>
+				<span>Flippable:</span>
+				<label for="flippableX">
+					<input type="checkbox" id="flippableX" title="If checked, the entity instances will be horizontally flippable."/>
+					Horizontal
+				</label>
+
+				<label for="flippableY">
+					<input type="checkbox" id="flippableY" title="If checked, the entity instances will be vertically flippable."/>
+					Vertical
+				</label>
+
+				<label for="flipAroundPivot">
+					<input type="checkbox" id="flipAroundPivot" title="If checked, the entity instances will flip around their pivot instead of just within their existing bounds."/>
+					Flip around pivot
+				</label>
+			</dd>
 
 			<dt>
 				<label>Editor visual</label>

--- a/app/assets/tpl/entityInstanceEditor.html
+++ b/app/assets/tpl/entityInstanceEditor.html
@@ -27,6 +27,22 @@
 				<span class="unit" title="Change coordinates unit"></span>
 			</dd>
 
+			<dt>
+				Flips
+				<info>How this Entity instance is oriented on the X and Y axes.</info>
+			</dt>
+			<dd class="flips">
+				<label>
+					<input type="checkbox" name="x"/>
+					Horizontal
+				</label>
+
+				<label>
+					<input type="checkbox" name="y"/>
+					Vertical
+				</label>
+			</dd>
+
 			<dt class="refs">
 				References to this entity
 				<info>This is a list of all other Entities having a Reference field pointing to this Entity.</info>

--- a/src/electron.renderer/GenericLevelElementGroup.hx
+++ b/src/electron.renderer/GenericLevelElementGroup.hx
@@ -216,8 +216,8 @@ class GenericLevelElementGroup {
 				case Entity(li, ei):
 					selectRender.beginFill(c, alpha);
 					selectRender.drawRect(
-						li.pxParallaxX + ( ei.x - ei.width * ei.def.pivotX ) * li.def.getScale(),
-						li.pxParallaxY + ( ei.y - ei.height * ei.def.pivotY ) * li.def.getScale(),
+						li.pxParallaxX + ( ei.x - ei.width * ei.getAdjustedPivotX() ) * li.def.getScale(),
+						li.pxParallaxY + ( ei.y - ei.height * ei.getAdjustedPivotY() ) * li.def.getScale(),
 						ei.width * li.def.getScale(),
 						ei.height * li.def.getScale()
 					);

--- a/src/electron.renderer/data/def/EntityDef.hx
+++ b/src/electron.renderer/data/def/EntityDef.hx
@@ -31,6 +31,9 @@ class EntityDef {
 
 	public var resizableX : Bool;
 	public var resizableY : Bool;
+	public var flippableX : Bool;
+	public var flippableY : Bool;
+	public var flipAroundPivot : Bool;
 	public var keepAspectRatio : Bool;
 	public var pivotX(default,set) : Float;
 	public var pivotY(default,set) : Float;
@@ -60,6 +63,8 @@ class EntityDef {
 		identifier = "Entity"+uid;
 		setPivot(0.5,1);
 		resizableX = resizableY = false;
+		flippableX = flippableY = false;
+		flipAroundPivot = false;
 		keepAspectRatio = false;
 		hollow = false;
 		tags = new Tags();
@@ -89,6 +94,14 @@ class EntityDef {
 			return tileRect;
 		else
 			return null;
+	}
+
+	public inline function getFlippedPivotX() {
+		return flipAroundPivot ? ((width - 1) / width) - pivotX : pivotX;
+	}
+
+	public inline function getFlippedPivotY() {
+		return flipAroundPivot ? ((height - 1) / height) - pivotY : pivotY;
 	}
 
 	function set_identifier(id:String) {
@@ -143,6 +156,9 @@ class EntityDef {
 		o.height = JsonTools.readInt( json.height, 16 );
 		o.resizableX = JsonTools.readBool( json.resizableX, false );
 		o.resizableY = JsonTools.readBool( json.resizableY, false );
+		o.flippableX = JsonTools.readBool( json.flippableX, false );
+		o.flippableY = JsonTools.readBool( json.flippableY, false );
+		o.flipAroundPivot = JsonTools.readBool( json.flipAroundPivot, false );
 		o.keepAspectRatio = JsonTools.readBool( json.keepAspectRatio, false );
 		o.doc = JsonTools.unescapeString( json.doc );
 
@@ -196,6 +212,9 @@ class EntityDef {
 			height: height,
 			resizableX: resizableX,
 			resizableY: resizableY,
+			flippableX: flippableX,
+			flippableY: flippableY,
+			flipAroundPivot: flipAroundPivot,
 			keepAspectRatio: keepAspectRatio,
 			tileOpacity: JsonTools.writeFloat(tileOpacity),
 			fillOpacity: JsonTools.writeFloat(fillOpacity),

--- a/src/electron.renderer/display/EntityRender.hx
+++ b/src/electron.renderer/display/EntityRender.hx
@@ -96,15 +96,21 @@ class EntityRender extends dn.Process {
 			ed = ei.def;
 
 
+
 		var w = ei!=null ? ei.width : ed.width;
 		var h = ei!=null ? ei.height : ed.height;
 		var color = ei!=null ? ei.getSmartColor(false) : ed.color;
 
+		var flipX = (ei!=null && M.hasBit(ei.flips,0));
+		var flipY = (ei!=null && M.hasBit(ei.flips,1));
+		var pivotX = ei!=null ? ei.getAdjustedPivotX() : ed.pivotX;
+		var pivotY = ei!=null ? ei.getAdjustedPivotY() : ed.pivotY;
+
 		var wrapper = new h2d.Object();
 
 		var g = new h2d.Graphics(wrapper);
-		g.x = Std.int( -w*ed.pivotX + (ld!=null ? ld.pxOffsetX : 0) );
-		g.y = Std.int( -h*ed.pivotY + (ld!=null ? ld.pxOffsetY : 0) );
+		g.x = Std.int( -w*pivotX + (ld!=null ? ld.pxOffsetX : 0));
+		g.y = Std.int( -h*pivotY + (ld!=null ? ld.pxOffsetY : 0));
 
 		var zoomScale = 1 / Editor.ME.camera.adjustedZoom;
 
@@ -129,13 +135,15 @@ class EntityRender extends dn.Process {
 				// Texture
 				var td = Editor.ME.project.defs.getTilesetDef(rect.tilesetUid);
 				var t = td.getTileRect(rect);
+				t.xFlip = flipX;
+				t.yFlip = flipY;
 				var alpha = ed.tileOpacity;
 				switch mode {
 					case Stretch:
 						var bmp = new h2d.Bitmap(t, wrapper);
 						if( ld!=null )
 							bmp.setPosition(ld.pxOffsetX, ld.pxOffsetY);
-						bmp.tile.setCenterRatio(ed.pivotX, ed.pivotY);
+						bmp.tile.setCenterRatio(pivotX, pivotY);
 						bmp.alpha = alpha;
 
 						bmp.scaleX = w / bmp.tile.width;
@@ -145,17 +153,21 @@ class EntityRender extends dn.Process {
 						var bmp = new h2d.Bitmap(t, wrapper);
 						if( ld!=null )
 							bmp.setPosition(ld.pxOffsetX, ld.pxOffsetY);
-						bmp.tile.setCenterRatio(ed.pivotX, ed.pivotY);
+						bmp.tile.setCenterRatio(pivotX, pivotY);
 						bmp.alpha = alpha;
 
 						var s = M.fmin(w / bmp.tile.width, h / bmp.tile.height);
 						bmp.setScale(s);
 
 					case Repeat:
+						// Invert flips to prevent broken rendering.
+						t.xFlip = false;
+						t.yFlip = false;
 						var tt = new dn.heaps.TiledTexture(t, w,h, wrapper);
+
 						tt.alpha = alpha;
-						tt.x = -w*ed.pivotX + (ld==null ? 0 : ld.pxOffsetX);
-						tt.y = -h*ed.pivotY + (ld==null ? 0 : ld.pxOffsetY);
+						tt.x = -w*pivotX + (ld==null ? 0 : ld.pxOffsetX);
+						tt.y = -h*pivotY + (ld==null ? 0 : ld.pxOffsetY);
 
 					case Cover:
 						var bmp = new h2d.Bitmap(wrapper);
@@ -167,11 +179,13 @@ class EntityRender extends dn.Process {
 						final fw = M.fmin(w, t.width*s) / s;
 						final fh = M.fmin(h, t.height*s) / s;
 						bmp.tile = t.sub(
-							t.width*ed.pivotX - fw*ed.pivotX,
-							t.height*ed.pivotY - fh*ed.pivotY,
+							t.width*pivotX - fw*pivotX,
+							t.height*pivotY - fh*pivotY,
 							fw,fh
 						);
-						bmp.tile.setCenterRatio(ed.pivotX, ed.pivotY);
+						bmp.tile.xFlip = t.xFlip;
+						bmp.tile.yFlip = t.yFlip;
+						bmp.tile.setCenterRatio(pivotX, pivotY);
 						bmp.setScale(s);
 
 					case FullSizeCropped:
@@ -181,11 +195,13 @@ class EntityRender extends dn.Process {
 						final fw = M.fmin(w, t.width);
 						final fh = M.fmin(h, t.height);
 						bmp.tile = t.sub(
-							t.width*ed.pivotX - fw*ed.pivotX,
-							t.height*ed.pivotY - fh*ed.pivotY,
+							t.width*pivotX - fw*pivotX,
+							t.height*pivotY - fh*pivotY,
 							fw, fh
 						);
-						bmp.tile.setCenterRatio(ed.pivotX, ed.pivotY);
+						bmp.tile.xFlip = t.xFlip;
+						bmp.tile.yFlip = t.yFlip;
+						bmp.tile.setCenterRatio(pivotX, pivotY);
 						bmp.alpha = alpha;
 
 					case FullSizeUncropped:
@@ -193,7 +209,7 @@ class EntityRender extends dn.Process {
 						if( ld!=null )
 							bmp.setPosition(ld.pxOffsetX, ld.pxOffsetY);
 
-						bmp.tile.setCenterRatio(ed.pivotX, ed.pivotY);
+						bmp.tile.setCenterRatio(pivotX, pivotY);
 						bmp.alpha = alpha;
 
 					case NineSlice:
@@ -207,9 +223,8 @@ class EntityRender extends dn.Process {
 						sg.tileCenter = true;
 						sg.width = w;
 						sg.height = h;
-						sg.x = -w*ed.pivotX + (ld==null ? 0 : ld.pxOffsetX);
-						sg.y = -h*ed.pivotY + (ld==null ? 0 : ld.pxOffsetY);
-
+						sg.x = -w*pivotX + (ld==null ? 0 : ld.pxOffsetX);
+						sg.y = -h*pivotY + (ld==null ? 0 : ld.pxOffsetY);
 				}
 			}
 		}
@@ -250,11 +265,18 @@ class EntityRender extends dn.Process {
 			}
 
 		// Pivot
+
+		// Adjust pivot rendering position based on our flip statuses.
+		var pivotX = ((ed.flipAroundPivot && flipX) ? ((w - 1) / w) - ed.pivotX : ed.pivotX);
+		var pivotY = ((ed.flipAroundPivot && flipY) ? ((h - 1) / h) - ed.pivotY : ed.pivotY);
+
 		g.lineStyle(0);
+		// Draw pivot background.
 		g.beginFill(0x0, 0.4);
-		g.drawRect(w*ed.pivotX-1, h*ed.pivotY-1, 3,3);
+		g.drawRect(w*pivotX-1, h*pivotY-1, 3,3);
+		// Draw pivot foreground.
 		g.beginFill(color, 1);
-		g.drawRect(w*ed.pivotX, h*ed.pivotY, 1,1);
+		g.drawRect(w*pivotX, h*pivotY, 1,1);
 
 		return {
 			wrapper: wrapper,
@@ -354,33 +376,35 @@ class EntityRender extends dn.Process {
 			fieldGraphics.alpha = fullVis ? 1 : ei._li.def.inactiveOpacity;
 		}
 
+		var pivX = M.hasBit(ei.flips, 0) ? ed.getFlippedPivotX() : ed.pivotX;
+		var pivY = M.hasBit(ei.flips, 1) ? ed.getFlippedPivotY() : ed.pivotY;
 
 		// Identifier
 		if( identifier!=null ) {
 			identifier.visible = fullVis || !ei._li.def.hideFieldsWhenInactive;
 			identifier.setScale(zoomScale);
-			identifier.x = Std.int( -ei.width*ed.pivotX - identifier.textWidth*0.5*identifier.scaleX + ei.width*0.5 );
-			identifier.y = Std.int( -identifier.textHeight*identifier.scaleY - ei.height*ed.pivotY );
+			identifier.x = Std.int( -ei.width*pivX - identifier.textWidth*0.5*identifier.scaleX + ei.width*0.5 );
+			identifier.y = Std.int( -identifier.textHeight*identifier.scaleY - ei.height*pivY );
 		}
 
 		// Update field wrappers
 		above.visible = center.visible = beneath.visible = fullVis || !ei._li.def.hideFieldsWhenInactive;
 		if( above.visible ) {
 			above.setScale(zoomScale);
-			above.x = M.round( -ei.width*ed.pivotX - above.outerWidth*0.5*above.scaleX + ei.width*0.5 );
-			above.y = Std.int( -above.outerHeight*above.scaleY - ei.height*ed.pivotY );
+			above.x = M.round( -ei.width*pivX - above.outerWidth*0.5*above.scaleX + ei.width*0.5 );
+			above.y = Std.int( -above.outerHeight*above.scaleY - ei.height*pivY );
 			if( identifier!=null )
 				above.y -= identifier.textHeight*identifier.scaleY;
 			above.alpha = 1;
 
 			center.setScale(zoomScale);
-			center.x = Std.int( -ei.width*ed.pivotX - center.outerWidth*0.5*center.scaleX + ei.width*0.5 );
-			center.y = Std.int( -ei.height*ed.pivotY - center.outerHeight*0.5*center.scaleY + ei.height*0.5);
+			center.x = Std.int( -ei.width*pivX - center.outerWidth*0.5*center.scaleX + ei.width*0.5 );
+			center.y = Std.int( -ei.height*pivY - center.outerHeight*0.5*center.scaleY + ei.height*0.5);
 			center.alpha = 1;
 
 			beneath.setScale(zoomScale);
-			beneath.x = Std.int( -ei.width*ed.pivotX - beneath.outerWidth*0.5*beneath.scaleX + ei.width*0.5 );
-			beneath.y = Std.int( ei.height*(1-ed.pivotY) );
+			beneath.x = Std.int( -ei.width*pivX - beneath.outerWidth*0.5*beneath.scaleX + ei.width*0.5 );
+			beneath.y = Std.int( ei.height*(1-pivY) );
 			beneath.alpha = 1;
 		}
 	}

--- a/src/electron.renderer/display/LevelRender.hx
+++ b/src/electron.renderer/display/LevelRender.hx
@@ -396,8 +396,8 @@ class LevelRender extends dn.Process {
 	public inline function bleepEntity(ei:data.inst.EntityInstance, ?overrideColor:Int, spd=1.0) : Bleep {
 		return bleepLayerRectPx(
 			ei._li,
-			Std.int( (ei.x-ei.width*ei.def.pivotX) * ei._li.def.getScale() ),
-			Std.int( (ei.y-ei.height*ei.def.pivotY) * ei._li.def.getScale() ),
+			Std.int( (ei.x-ei.width*ei.getAdjustedPivotX()) * ei._li.def.getScale() ),
+			Std.int( (ei.y-ei.height*ei.getAdjustedPivotY()) * ei._li.def.getScale() ),
 			ei.width,
 			ei.height,
 			overrideColor!=null ? overrideColor : ei.getSmartColor(true),

--- a/src/electron.renderer/tool/ResizeTool.hx
+++ b/src/electron.renderer/tool/ResizeTool.hx
@@ -268,14 +268,14 @@ class ResizeTool extends Tool<Int> {
 					if( ei.customHeight==ei.def.height ) ei.customHeight = null;
 
 					switch draggedHandle {
-						case Left, TopLeft, BottomLeft: if( ei.def.pivotX==0 ) ei.x -= ( ei.width - oldW );
-						case Right, TopRight, BottomRight: if( ei.def.pivotX==1 ) ei.x += ( ei.width - oldW );
+						case Left, TopLeft, BottomLeft: if( ei.getAdjustedPivotX()==0 ) ei.x -= ( ei.width - oldW );
+						case Right, TopRight, BottomRight: if( ei.getAdjustedPivotX()==1 ) ei.x += ( ei.width - oldW );
 						case _:
 					}
 
 					switch draggedHandle {
-						case Top, TopLeft, TopRight: if( ei.def.pivotY==0 ) ei.y -= ( ei.height - oldH );
-						case Bottom, BottomLeft, BottomRight: if( ei.def.pivotY==1 ) ei.y += ( ei.height - oldH );
+						case Top, TopLeft, TopRight: if( ei.getAdjustedPivotY()==0 ) ei.y -= ( ei.height - oldH );
+						case Bottom, BottomLeft, BottomRight: if( ei.getAdjustedPivotY()==1 ) ei.y += ( ei.height - oldH );
 						case _:
 					}
 

--- a/src/electron.renderer/tool/lt/EntityTool.hx
+++ b/src/electron.renderer/tool/lt/EntityTool.hx
@@ -77,15 +77,17 @@ class EntityTool extends tool.LayerTool<Int> {
 
 	function getPlacementX(m:Coords) {
 		var pivot = flipX ? curEntityDef.getFlippedPivotX() : curEntityDef.pivotX;
+		var size = curLayerInstance.def.gridSize;
 		return snapToGrid()
-			? M.round( ( m.cx + pivot ) * curLayerInstance.def.gridSize )
+			? M.round( ( m.cx * size ) + M.floor( pivot * size ) )
 			: m.levelX;
 	}
 
 	function getPlacementY(m:Coords) {
 		var pivot = flipY ? curEntityDef.getFlippedPivotY() : curEntityDef.pivotY;
+		var size = curLayerInstance.def.gridSize;
 		return snapToGrid()
-			? M.round( ( m.cy + pivot ) * curLayerInstance.def.gridSize)
+			? M.round( ( m.cy * size ) + M.floor( pivot * size ) )
 			: m.levelY;
 	}
 

--- a/src/electron.renderer/ui/Cursor.hx
+++ b/src/electron.renderer/ui/Cursor.hx
@@ -203,14 +203,14 @@ class Cursor {
 							final ry = ei.height*0.5;
 							g.lineStyle(1, 0xffcc00, 1);
 							g.drawEllipse(
-								(0.5-def.pivotX)*ei.width, (0.5-def.pivotY)*ei.height,
+								(0.5-ei.getAdjustedPivotX())*ei.width, (0.5-ei.getAdjustedPivotY())*ei.height,
 								rx+pad, ry+pad,
 								0, rx<=16 && ry<=16 ? 24 : 0
 							);
 
 						case Rectangle, Tile:
 							g.lineStyle(1, 0xffcc00, 1);
-							renderBeveledRect(g, -def.pivotX*ei.width-pad, -def.pivotY*ei.height-pad, ei.width+pad*2, ei.height+pad*2);
+							renderBeveledRect(g, -ei.getAdjustedPivotX()*ei.width-pad, -ei.getAdjustedPivotY()*ei.height-pad, ei.width+pad*2, ei.height+pad*2);
 					}
 				}
 

--- a/src/electron.renderer/ui/EntityInstanceEditor.hx
+++ b/src/electron.renderer/ui/EntityInstanceEditor.hx
@@ -262,6 +262,33 @@ class EntityInstanceEditor extends dn.Process {
 		if( UNIT_GRID )
 			i.setUnit(ei._li.def.gridSize);
 
+		// Flip block
+		var jFlips = jPropsForm.find(".flips");
+
+		// X
+		var i = new form.input.BoolInput(
+			jFlips.find("[name=x]"),
+			()->(M.hasBit(ei.flips,0)),
+			(v)->{
+				ei.flips = M.makeBitsFromBools(!M.hasBit(ei.flips, 0), M.hasBit(ei.flips, 1));
+			}
+		);
+		i.setEnabled( ei.def.flippableX );
+		i.linkEvent( EntityInstanceChanged(ei) );
+		i.onChange = ()->onEntityFieldChanged();
+
+		// Y
+		var i = new form.input.BoolInput(
+			jFlips.find("[name=y]"),
+			()->(M.hasBit(ei.flips,1)),
+			(v)->{
+				ei.flips = M.makeBitsFromBools(M.hasBit(ei.flips, 0), !M.hasBit(ei.flips, 1));
+			}
+		);
+		i.setEnabled( ei.def.flippableY );
+		i.linkEvent( EntityInstanceChanged(ei) );
+		i.onChange = ()->onEntityFieldChanged();
+
 
 		// References to this
 		var refs = project.getEntityInstancesReferingTo(ei);

--- a/src/electron.renderer/ui/modal/panel/EditEntityDefs.hx
+++ b/src/electron.renderer/ui/modal/panel/EditEntityDefs.hx
@@ -210,6 +210,15 @@ class EditEntityDefs extends ui.modal.Panel {
 		i.onChange = editor.ge.emit.bind(EntityDefChanged);
 		i.setEnabled( curEntity.resizableX && curEntity.resizableY );
 
+		// Flippable
+		var i = Input.linkToHtmlInput( curEntity.flippableX, jEntityForm.find("input#flippableX") );
+		i.onChange = editor.ge.emit.bind(EntityDefChanged);
+		var i = Input.linkToHtmlInput( curEntity.flippableY, jEntityForm.find("input#flippableY") );
+		i.onChange = editor.ge.emit.bind(EntityDefChanged);
+
+		var i = Input.linkToHtmlInput( curEntity.flipAroundPivot, jEntityForm.find("input#flipAroundPivot") );
+		i.onChange = editor.ge.emit.bind(EntityDefChanged);
+
 		var i = Input.linkToHtmlInput( curEntity.height, jEntityForm.find("input[name='height']") );
 		i.setBounds(1,2048);
 		i.onChange = editor.ge.emit.bind(EntityDefChanged);


### PR DESCRIPTION
Builds on https://github.com/deepnight/ldtk/pull/809 to introduce an Entity definition modifier to flip around the pivot rather than in bounds.

This has also been reworked to be based on dev-1.2.6 rather than master, which should make integration into the next release easier.

This requires another API fork, a PR for which exists at https://github.com/deepnight/ldtk-haxe-api/pull/27. Expect CI to fail since this requires said API fork.

The resize tool appears to be somewhat buggy with flipped Entities, but this is not unique to my flips and has more to do with underlying bugs in the resize tool. As such, it should be fixed in another PR rather than this one.

All other relevant information exists on the original PR in regard to how flips are handled in general.

Images:

![image](https://user-images.githubusercontent.com/33508026/223542095-9c654b8a-bb51-4bb1-969f-ce17c59f3945.png)

![image](https://user-images.githubusercontent.com/33508026/223542290-260d4479-71d0-4952-90c1-4f485549deec.png)