### PR TITLE
Fix rule editor when AutoLayer references an IntGrid

### DIFF
--- a/src/electron.renderer/ui/modal/dialog/RuleEditor.hx
+++ b/src/electron.renderer/ui/modal/dialog/RuleEditor.hx
@@ -39,7 +39,7 @@ class RuleEditor extends ui.modal.Dialog {
 
 		// Default current value
 		if( curValue<0 )
-			for(iv in layerDef.getAllIntGridValues()) {
+			for(iv in sourceDef.getAllIntGridValues()) {
 				curValue = iv.value;
 				break;
 			}
@@ -168,7 +168,7 @@ class RuleEditor extends ui.modal.Dialog {
 		});
 
 		// Values picker
-		for(v in layerDef.getAllIntGridValues()) {
+		for(v in sourceDef.getAllIntGridValues()) {
 			var jVal = new J('<li/>');
 			jVal.appendTo(jValues);
 


### PR DESCRIPTION
Fixes https://github.com/deepnight/ldtk/issues/921

![image](https://github.com/deepnight/ldtk/assets/1260622/bf737655-240a-4991-896d-0cd407532414)

I ran it locally for my example project and it seems to resolve the issue: the values show up in the list now.

I suspect that https://github.com/deepnight/ldtk/commit/a56d3d05be574a105218f1ea7c98d54b5b3a6158 introduced the problem.