### PR TITLE
Persist tile custom data to Tiled custom properties

### DIFF
--- a/src/electron.renderer/exporter/Tiled.hx
+++ b/src/electron.renderer/exporter/Tiled.hx
@@ -1,5 +1,6 @@
 package exporter;
 
+import haxe.Json;
 import ldtk.Json;
 
 
@@ -145,6 +146,44 @@ class Tiled extends Exporter {
 			image.set("source", relPath);
 			image.set("width", ""+td.pxWid);
 			image.set("height", ""+td.pxHei);
+
+			if (td.hasAnyTileCustomData()) {
+				for (tileId in 0...count) {
+					var tileData = td.getTileCustomData(tileId);
+					if (tileData != null) {
+						var tile = Xml.createElement("tile");
+						tile.set("id", "" + tileId);
+						var properties = Xml.createElement("properties");
+						var dataFields = Json.parse(tileData);
+						for (key in Reflect.fields(dataFields)) {
+							var value = Reflect.field(dataFields, key);
+							if (value is Array) continue;
+							var property = Xml.createElement("property");
+							property.set("name", key);
+							switch (Type.typeof(value)) {
+								case TBool:
+									property.set("type", "bool");
+								case TInt:
+									property.set("type", "int");
+								case TFloat:
+									property.set("type", "float");
+								case TObject:
+									property = null;
+								case _:
+							}
+							if ( property != null ) {
+								property.set("value", ""+value);
+								properties.addChild(property);
+							}
+						}
+						if (properties.firstChild() != null) {
+							log.add("tileset", '  Adding custom properties for tile: ${tileId}');
+							tile.addChild(properties);
+							tileset.addChild(tile);
+						}
+					}
+				}
+			}
 
 			tilesetGids.set(td.uid, gid);
 			gid+=count;

--- a/src/electron.renderer/exporter/Tiled.hx
+++ b/src/electron.renderer/exporter/Tiled.hx
@@ -147,20 +147,20 @@ class Tiled extends Exporter {
 			image.set("width", ""+td.pxWid);
 			image.set("height", ""+td.pxHei);
 
-			if (td.hasAnyTileCustomData()) {
-				for (tileId in 0...count) {
+			if ( td.hasAnyTileCustomData() ) {
+				for ( tileId in 0...count ) {
 					var tileData = td.getTileCustomData(tileId);
-					if (tileData != null) {
+					if ( tileData != null ) {
 						var tile = Xml.createElement("tile");
 						tile.set("id", "" + tileId);
 						var properties = Xml.createElement("properties");
 						var dataFields = Json.parse(tileData);
-						for (key in Reflect.fields(dataFields)) {
+						for ( key in Reflect.fields(dataFields) ) {
 							var value = Reflect.field(dataFields, key);
-							if (value is Array) continue;
+							if ( value is Array ) continue;
 							var property = Xml.createElement("property");
 							property.set("name", key);
-							switch (Type.typeof(value)) {
+							switch ( Type.typeof(value) ) {
 								case TBool:
 									property.set("type", "bool");
 								case TInt:
@@ -176,7 +176,7 @@ class Tiled extends Exporter {
 								properties.addChild(property);
 							}
 						}
-						if (properties.firstChild() != null) {
+						if ( properties.firstChild() != null ) {
 							log.add("tileset", '  Adding custom properties for tile: ${tileId}');
 							tile.addChild(properties);
 							tileset.addChild(tile);


### PR DESCRIPTION
PR for issue I created earlier today - https://github.com/deepnight/ldtk/issues/988#issue-1962690981

These changes will only add custom properties for root-level JSON key/value pairs for each tile in the tileset that has custom data defined. It will ignore plain text custom data or object/array values if the custom data is a JSON. The properties will be added with their name, respective type of `bool`, `string`, `int`, or `float`, and value. The `string` type does not add the type qualifier to the property element as this was the behavior I observed when saving custom properties directly in Tiled.

This is my first time writing any Haxe so please go easy on me!