### PR TITLE
Remove macos empty menu set which causes edit/copy/paste to not have …

### DIFF
--- a/src/electron.main/ElectronMain.hx
+++ b/src/electron.main/ElectronMain.hx
@@ -101,7 +101,6 @@ class ElectronMain {
 		#if debug
 		enableDebugMenu();
 		#else
-		electron.main.Menu.setApplicationMenu( electron.main.Menu.buildFromTemplate( [] ) ); // macos
 		mainWindow.removeMenu(); // windows
 		#end
 


### PR DESCRIPTION
…menu roles - this prevents cut and paste working on osx currently.