### PR TITLE
fix spelling error, change default value tooltip for strings

### DIFF
--- a/app/assets/tpl/fieldDefsForm.html
+++ b/app/assets/tpl/fieldDefsForm.html
@@ -56,7 +56,7 @@
 
 	<dt class="full"> <h3>Value specifications</h3> </dt>
 
-	<dt class="F_Int F_Float F_String">
+	<dt class="F_Int F_Float">
 		<label for="fDef">Default value</label>
 		<info>This is the default number value for this field, unless overridden with something else.</info>
 	</dt>
@@ -65,7 +65,7 @@
 	</dd>
 
 
-	<dt class="F_Text">
+	<dt class="F_Text F_String">
 		<label for="fDefMultiLines">Default value</label>
 		<info>This is the default text for this field, unless modified manually.</info>
 	</dt>

--- a/app/assets/tpl/pages/editor.html
+++ b/app/assets/tpl/pages/editor.html
@@ -43,7 +43,7 @@
 			<div class="icon zen off"></div>
 		</li>
 
-		<li class="grid" title="**Grid** Show the layer grid. In supported layer types, hiding the grid will also allow free positionning of elements." keys="G" tip="right">
+		<li class="grid" title="**Grid** Show the layer grid. In supported layer types, hiding the grid will also allow free positioning of elements." keys="G" tip="right">
 			<div class="icon gridOn on"></div>
 			<div class="icon gridOff off"></div>
 		</li>


### PR DESCRIPTION
Small PR that fixes the issues below. Notably involved moving the class name `F_String` from the tooltip used by numerical properties to the tooltip used by Text properties.

![ldtk-commit](https://github.com/user-attachments/assets/67d5518a-7b2b-4b0e-9940-503d9b151b3f)
