### PR TITLE
Fix excessive memory use with large external-level projects

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,5 +38,8 @@
 	"devDependencies": {
 		"electron": "^24.1.2",
 		"electron-builder": "^23.6.0"
+	},
+	"allowScripts": {
+		"electron@24.8.8": true
 	}
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.4
+
+- Fixed excessive memory use when loading and saving large projects with external level files (#1172)
+
 # 1.5.3
 
 - Fixed a crash when trying to add a newly created Entity

--- a/src/electron.renderer/EditorTypes.hx
+++ b/src/electron.renderer/EditorTypes.hx
@@ -200,7 +200,7 @@ enum TilePickerDisplayMode {
 
 typedef FileSavingData = {
 	var projectJsonStr: String;
-	var externLevels: Array<{ jsonStr:String, relPath:String, id:String }>;
+	var externLevels: Array<{ relPath:String, id:String, uid:Int }>;
 }
 
 enum LevelError {

--- a/src/electron.renderer/data/Level.hx
+++ b/src/electron.renderer/data/Level.hx
@@ -1,10 +1,15 @@
 package data;
 
+private enum LevelJsonCache {
+	InMemory(str:String, json:ldtk.Json.LevelJson);
+	ExternalFile(absPath:String);
+}
+
 class Level {
 	var _project : Project;
 	public var _world : World;
 
-	var _cachedJson : Null<{ str:String, json:ldtk.Json.LevelJson }>;
+	var _jsonCache : Null<LevelJsonCache>;
 
 	@:allow(data.Project, data.World)
 	public var uid(default,null) : Int;
@@ -144,12 +149,15 @@ class Level {
 
 
 
-	public function toJson(ignoreCache=false) : ldtk.Json.LevelJson {
-		if( !ignoreCache && hasJsonCache() ) {
+	public function toJson(ignoreCache=false, skipLayerInstances=false) : ldtk.Json.LevelJson {
+		if( !ignoreCache && !skipLayerInstances && hasJsonCache() ) {
 			var o = getCacheJsonObject();
-			if( !_project.externalLevels )
-				Reflect.deleteField(o, dn.data.JsonPretty.HEADER_VALUE_NAME);
-			return o;
+			if( o!=null ) {
+				if( !_project.externalLevels )
+					Reflect.deleteField(o, dn.data.JsonPretty.HEADER_VALUE_NAME);
+				return o;
+			}
+			invalidateJsonCache();
 		}
 
 		// World coords are not stored in JSON for automatically organized layouts
@@ -204,12 +212,12 @@ class Level {
 					all.push( getFieldInstance(fd,true).toJson() );
 				all;
 			},
-			layerInstances: layerInstances.map( li->li.toJson() ),
+			layerInstances: skipLayerInstances ? null : layerInstances.map( li->li.toJson() ),
 			__neighbours: ignoreCache ? [] : getNeighboursJson(),
 		}
 
-		// Cache this json
-		if( !ignoreCache )
+		// External projects are cached only after their level file was written successfully.
+		if( !ignoreCache && !skipLayerInstances )
 			setJsonCache(json, false);
 
 		return json;
@@ -282,7 +290,7 @@ class Level {
 			+ "." + Const.LEVEL_EXTENSION;
 	}
 
-	public static function fromJson(p:Project, w:World, json:ldtk.Json.LevelJson, registerToQuickAccess:Bool) {
+	public static function fromJson(p:Project, w:World, json:ldtk.Json.LevelJson, registerToQuickAccess:Bool, ?externalJsonAbsPath:String) {
 		if( json.iid==null )
 			json.iid = p.generateUniqueId_UUID();
 
@@ -317,9 +325,13 @@ class Level {
 				l.fieldInstances.set(fi.defUid, fi);
 			}
 
-		// Init cache
-		crawlObjectRec(json); // Because haxe.Json.parse unescapes "\n" chars, we need to re-escape them before caching the JSON object
-		l.setJsonCache(json, true);
+		// External levels keep only their source path. Embedded levels retain the existing in-memory cache.
+		if( externalJsonAbsPath!=null )
+			l.setJsonCacheFromExternalFile(externalJsonAbsPath);
+		else if( json.layerInstances!=null ) {
+			crawlObjectRec(json); // Because haxe.Json.parse unescapes "\n" chars, we need to re-escape them before caching the JSON object
+			l.setJsonCache(json, true);
+		}
 
 		return l;
 	}
@@ -371,22 +383,41 @@ class Level {
 	}
 
 
-	public inline function hasJsonCache() return _cachedJson!=null;
-	public inline function invalidateJsonCache() _cachedJson = null;
+	public inline function hasJsonCache() return _jsonCache!=null;
+	public inline function invalidateJsonCache() _jsonCache = null;
 	public function rebuildCache() {
-		_cachedJson = null;
-		toJson();
+		invalidateJsonCache();
+		if( !_project.externalLevels )
+			toJson();
 	}
 
 	function setJsonCache(json:ldtk.Json.LevelJson, skipHeader:Bool) {
-		_cachedJson = {
-			str: ui.ProjectSaver.jsonStringify(_project, json, skipHeader ),
-			json: json,
+		if( !_project.externalLevels )
+			_jsonCache = InMemory(
+				ui.ProjectSaver.jsonStringify(_project, json, skipHeader),
+				json
+			);
+	}
+
+	public function setJsonCacheFromExternalFile(absPath:String) {
+		_jsonCache = ExternalFile(absPath);
+	}
+
+	public function getExternalJsonCachePath() : Null<String> {
+		return switch _jsonCache {
+			case ExternalFile(absPath): absPath;
+			case InMemory(_, _), null: null;
 		}
 	}
 
-	public inline function getCacheJsonObject() : Null<ldtk.Json.LevelJson> {
-		return hasJsonCache() ? _cachedJson.json : null;
+	public function getCacheJsonObject() : Null<ldtk.Json.LevelJson> {
+		return switch _jsonCache {
+			case InMemory(_, json): json;
+			case ExternalFile(absPath):
+				try haxe.Json.parse(NT.readFileString(absPath))
+				catch(_) null;
+			case null: null;
+		}
 	}
 
 	public inline function getDisplayIdentifier() {
@@ -394,7 +425,13 @@ class Level {
 	}
 
 	public function getCacheJsonString() : Null<String> {
-		return hasJsonCache() ? _cachedJson.str : null;
+		return switch _jsonCache {
+			case InMemory(str, _): str;
+			case ExternalFile(absPath):
+				try NT.readFileString(absPath)
+				catch(_) null;
+			case null: null;
+		}
 	}
 
 	public function getBgTileInfos() : Null<{ imgData:data.DataTypes.CachedImage, tx:Float, ty:Float, tw:Float, th:Float, dispX:Int, dispY:Int, sx:Float, sy:Float }> {

--- a/src/electron.renderer/data/Project.hx
+++ b/src/electron.renderer/data/Project.hx
@@ -627,7 +627,7 @@ class Project {
 	}
 
 
-	public function toJson() : ldtk.Json.ProjectJson {
+	public function toJson(skipLayerInstances=false) : ldtk.Json.ProjectJson {
 		var json : ldtk.Json.ProjectJson = {
 			iid: iid,
 			jsonVersion: jsonVersion,
@@ -677,8 +677,8 @@ class Project {
 			},
 
 			defs: defs.toJson(this),
-			levels: hasFlag(MultiWorlds) ? [] : worlds[0].levels.map( (l)->l.toJson() ),
-			worlds: hasFlag(MultiWorlds) ? worlds.map( (w)->w.toJson() ) : [],
+			levels: hasFlag(MultiWorlds) ? [] : worlds[0].levels.map( (l)->l.toJson(false, skipLayerInstances) ),
+			worlds: hasFlag(MultiWorlds) ? worlds.map( (w)->w.toJson(skipLayerInstances) ) : [],
 			dummyWorldIid: dummyWorldIid,
 
 			// toc: {

--- a/src/electron.renderer/data/World.hx
+++ b/src/electron.renderer/data/World.hx
@@ -34,7 +34,7 @@ class World {
 	}
 
 
-	public function toJson() : ldtk.Json.WorldJson {
+	public function toJson(skipLayerInstances=false) : ldtk.Json.WorldJson {
 		return {
 			iid: iid,
 			identifier: identifier,
@@ -43,7 +43,7 @@ class World {
 			worldGridWidth: worldGridWidth,
 			worldGridHeight: worldGridHeight,
 			worldLayout: JsonTools.writeEnum(worldLayout, false),
-			levels: levels.map( l->l.toJson() ),
+			levels: levels.map( l->l.toJson(false, skipLayerInstances) ),
 		}
 	}
 

--- a/src/electron.renderer/page/CrashReport.hx
+++ b/src/electron.renderer/page/CrashReport.hx
@@ -106,7 +106,7 @@ class CrashReport extends Page {
 					for(l in data.externLevels) {
 						var lfp = dn.FilePath.fromFile(dir.full+"/"+l.relPath);
 						NT.createDirs(lfp.directory);
-						NT.writeFileString(lfp.full, l.jsonStr);
+						ui.ProjectSaver.writeExternalLevelFile(unsavedProject, l.uid, lfp.full, false);
 					}
 					jBackup.html("But don't worry, your work was saved in a backup file!");
 

--- a/src/electron.renderer/page/Home.hx
+++ b/src/electron.renderer/page/Home.hx
@@ -469,7 +469,6 @@ class Home extends Page {
 			function _createNew() {
 				var p = data.Project.createEmpty(fp.full);
 
-				var data = ui.ProjectSaver.prepareProjectSavingData(p);
 				new ui.ProjectSaver(this, p, (success)->{
 					if( success ) {
 						N.msg("New project created: "+p.filePath.full);

--- a/src/electron.renderer/ui/ProjectLoader.hx
+++ b/src/electron.renderer/ui/ProjectLoader.hx
@@ -105,6 +105,8 @@ class ProjectLoader {
 						null;
 					}
 					#end
+				json = null;
+				raw = null;
 			}
 		});
 
@@ -157,8 +159,10 @@ class ProjectLoader {
 
 										var raw = NT.readFileString(path);
 										var lJson = haxe.Json.parse(raw);
-										var l = data.Level.fromJson(p, w, lJson, true);
+										var l = data.Level.fromJson(p, w, lJson, true, path);
 										w.levels[curIdx] = l;
+										raw = null;
+										lJson = null;
 									}
 									catch(e:Dynamic) {
 										_failedLevel(w, curIdx, "Error while parsing level file "+l.externalRelPath);

--- a/src/electron.renderer/ui/ProjectSaver.hx
+++ b/src/electron.renderer/ui/ProjectSaver.hx
@@ -177,19 +177,23 @@ class ProjectSaver extends dn.Process {
 					beginNextState();
 
 			case CheckLevelCache:
-				// Rebuild levels cache if necessary
-				var ops : Array<ui.modal.Progress.ProgressOp> = [];
-				for(w in project.worlds)
-				for(l in w.levels) {
-					ops.push({
-						label: l.identifier,
-						cb: ()->{
-							if( !l.hasJsonCache() )
-								l.rebuildCache();
-						}
-					});
+				if( project.externalLevels )
+					beginNextState(); // Dirty external levels are serialized one at a time while saving.
+				else {
+					// Rebuild embedded level caches if necessary.
+					var ops : Array<ui.modal.Progress.ProgressOp> = [];
+					for(w in project.worlds)
+					for(l in w.levels) {
+						ops.push({
+							label: l.identifier,
+							cb: ()->{
+								if( !l.hasJsonCache() )
+									l.rebuildCache();
+							}
+						});
+					}
+					new ui.modal.Progress("Preparing levels...", ops, ()->beginNextState());
 				}
-				new ui.modal.Progress("Preparing levels...", ops, ()->beginNextState());
 
 
 			case SavingMainFile:
@@ -224,19 +228,34 @@ class ProjectSaver extends dn.Process {
 
 				if( project.externalLevels ) {
 					logState();
-					initDir(levelDir, Const.LEVEL_EXTENSION);
+					initDir(levelDir);
 
 					var ops = [];
+					var failed = false;
 					for(l in savingData.externLevels) {
 						var fp = dn.FilePath.fromFile( project.makeAbsoluteFilePath(l.relPath) );
+						var uid = l.uid;
+						var id = l.id;
 						ops.push({
-							label: "Level "+l.id,
+							label: "Level "+id,
 							cb: ()->{
-								NT.writeFileString(fp.full, l.jsonStr);
+								if( failed )
+									return;
+								try writeExternalLevelFile(project, uid, fp.full, true)
+								catch(err:Dynamic) {
+									failed = true;
+									App.LOG.error('Failed to save external level "$id": '+Std.string(err));
+									error( L.t._("Could not save external level ::level::. The previous file was preserved.", {level:id}) );
+								}
 							}
 						});
 					}
-					new ui.modal.Progress(Lang.t._("Saving levels"), ops, ()->beginNextState());
+					new ui.modal.Progress(Lang.t._("Saving levels"), ops, ()->{
+						if( !failed ) {
+							removeObsoleteExternalLevelFiles(project, savingData.externLevels);
+							beginNextState();
+						}
+					});
 				}
 				else {
 					// Remove previous external levels
@@ -664,6 +683,81 @@ class ProjectSaver extends dn.Process {
 		);
 	}
 
+	static function normalizePath(path:String) : String {
+		var nodePath : Dynamic = js.node.Require.require("path");
+		var out : String = nodePath.resolve(path);
+		var process : Dynamic = js.node.Require.require("process");
+		return process.platform=="win32" ? out.toLowerCase() : out;
+	}
+
+	static inline function samePath(a:String, b:String) {
+		return normalizePath(a)==normalizePath(b);
+	}
+
+	static function atomicFileOperation(targetAbsPath:String, writeTemp:String->Void) {
+		var fp = dn.FilePath.fromFile(targetAbsPath);
+		if( !NT.fileExists(fp.directory) )
+			NT.createDirs(fp.directory);
+
+		var process : Dynamic = js.node.Require.require("process");
+		var tmpPath = targetAbsPath+'.tmp-'+process.pid;
+		var fs : Dynamic = js.node.Require.require("fs");
+		try {
+			if( NT.fileExists(tmpPath) )
+				NT.removeFile(tmpPath);
+			writeTemp(tmpPath);
+			fs.renameSync(tmpPath, targetAbsPath);
+		}
+		catch(err:Dynamic) {
+			try if( NT.fileExists(tmpPath) ) NT.removeFile(tmpPath) catch(_) {}
+			throw err;
+		}
+	}
+
+	/** Write or copy one external level without retaining its JSON alongside other levels. */
+	public static function writeExternalLevelFile(p:data.Project, uid:Int, targetAbsPath:String, updateCache:Bool) {
+		var level = p.getLevelAnywhere(uid);
+		if( level==null )
+			throw 'Unknown level uid $uid';
+
+		var sourceAbsPath = level.getExternalJsonCachePath();
+		if( sourceAbsPath!=null && !NT.fileExists(sourceAbsPath) ) {
+			// Cached file was removed externally: re-serialize from live data instead
+			level.invalidateJsonCache();
+			sourceAbsPath = null;
+		}
+
+		if( sourceAbsPath!=null ) {
+			if( !samePath(sourceAbsPath, targetAbsPath) )
+				atomicFileOperation(targetAbsPath, (tmpPath)->NT.copyFile(sourceAbsPath, tmpPath));
+		}
+		else {
+			var jsonStr = jsonStringify(p, level.toJson());
+			atomicFileOperation(targetAbsPath, (tmpPath)->NT.writeFileString(tmpPath, jsonStr));
+			jsonStr = null;
+		}
+
+		if( updateCache )
+			level.setJsonCacheFromExternalFile(targetAbsPath);
+	}
+
+	static function removeObsoleteExternalLevelFiles(p:data.Project, levels:Array<{ relPath:String, id:String, uid:Int }>) {
+		var expected = new Map<String,Bool>();
+		for(l in levels)
+			expected.set( normalizePath(p.makeAbsoluteFilePath(l.relPath)), true );
+
+		var dir = p.getAbsExternalFilesDir();
+		if( !NT.fileExists(dir) )
+			return;
+		for(fileName in NT.readDir(dir)) {
+			var absPath = dn.FilePath.fromFile(dir+"/"+fileName);
+			if( NT.isDirectory(absPath.full) || absPath.extension==null || absPath.extension.toLowerCase()!=Const.LEVEL_EXTENSION )
+				continue;
+			if( !expected.exists(normalizePath(absPath.full)) )
+				NT.removeFile(absPath.full);
+		}
+	}
+
 	public static function prepareProjectSavingData(project:data.Project, forceSingleFile=false) : FileSavingData {
 		var savingData : FileSavingData = {
 			projectJsonStr: "?",
@@ -678,24 +772,24 @@ class ProjectSaver extends dn.Process {
 			savingData.projectJsonStr = jsonStringify( project, project.toJson() );
 		}
 		else {
-			// Separate level JSONs
+			// Keep only descriptors. Level contents are copied or serialized one at a time.
 			var idx = 0;
 			for(w in project.worlds)
 			for(l in w.levels)
 				savingData.externLevels.push({
-					jsonStr: !l.hasJsonCache() ? jsonStringify( project, l.toJson() ) : l.getCacheJsonString(),
 					relPath: l.makeExternalRelPath(idx++),
 					id: l.identifier,
+					uid: l.uid,
 				});
 
-			// Build project JSON without level data
+			// Build lightweight project stubs without constructing any layer JSON.
 			var idx = 0;
 			inline function _clearLevelData(levelJson:ldtk.Json.LevelJson) {
 				Reflect.deleteField(levelJson, dn.data.JsonPretty.HEADER_VALUE_NAME);
 				levelJson.layerInstances = null;
 				levelJson.externalRelPath = project.getLevelAnywhere(levelJson.uid).makeExternalRelPath(idx++);
 			}
-			var trimmedProjectJson = project.toJson();
+			var trimmedProjectJson = project.toJson(true);
 			if( project.hasFlag(MultiWorlds) ) {
 				for(worldJson in trimmedProjectJson.worlds)
 				for(levelJson in worldJson.levels)


### PR DESCRIPTION
Fixes #1172

Large projects with external levels were crashing the renderer because Electron's V8 heap is capped around 4GB (pointer compression), and every level was kept in memory 3 times: the live data, a parsed LevelJson object, and the pretty-printed JSON string. With the crasher project from the issue this goes over the cap before loading even finishes.

Changes:

- For external-level projects, the level JSON cache no longer keeps the string/object in RAM. It just points at the level's own `.ldtkl` file on disk, and reads it back only when actually needed.
- Saving doesn't wipe and rewrite the whole levels folder anymore. Unchanged levels are skipped entirely, renamed levels get their file copied, and only dirty levels are re-serialized — one at a time, so the peak memory during a save is a single level. Orphaned `.ldtkl` files are cleaned up after the save succeeds.
- The main project JSON is built with layer instances skipped instead of serializing everything and stripping fields afterwards.
- Crash backups go through the same one-level-at-a-time path.

Single-file projects keep the old in-memory cache, nothing changes for them.

Tested with the crasher project from the issue (55 levels, ~276MB): loads and saves fine now, renderer stays under 1GB where it used to hit 4GB and die. Also checked: saving without edits touches only the main `.ldtk` file, editing one level rewrites only that level's file, level rename/delete, save as to another folder, 0.9.3 project migration, and close/reopen round-trips (multi-world sample included).